### PR TITLE
Feat: hide search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Japanese ([@kons10](https://github.com/kons10))
   - Arabic ([@heshamoomar](https://github.com/heshamoomar))
 
+### Added
+
+- New setting to hide the search section allowing completely hiding the search bar and searh engines section
+
 ## [v3.3](https://github.com/prem-k-r/MaterialYouNewTab/compare/v3.2...v3.3) - Nov 23, 2025
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- New setting to hide the search section allowing completely hiding the search bar and searh engines section
+- New setting to hide the search section, allowing you to completely hide the search bar and search engines section.
 
 ## [v3.3](https://github.com/prem-k-r/MaterialYouNewTab/compare/v3.2...v3.3) - Nov 23, 2025
 

--- a/index.html
+++ b/index.html
@@ -1560,7 +1560,7 @@
                             </div>
                         </div>
 
-                        <div class="ttcont weather">
+                        <div class="ttcont">
                             <div class="texts">
                                 <div class="bigText" id="hideSearch">Hide Search</div>
                                 <div class="infoText" id="hideSearchInfo">

--- a/index.html
+++ b/index.html
@@ -1559,6 +1559,19 @@
                                 <button class="savebtn" id="saveAPI">Save</button>
                             </div>
                         </div>
+
+                        <div class="ttcont weather">
+                            <div class="texts">
+                                <div class="bigText" id="hideSearch">Hide Search</div>
+                                <div class="infoText" id="hideSearchInfo">
+                                    Hide the search bar and search engine sections entirely
+                                </div>
+                            </div>
+                            <label class="switch">
+                                <input id="hideSearchCheckbox" type="checkbox">
+                                <span class="toggle"></span>
+                            </label>
+                        </div>
                     </div>
                     <div class="divider" id="divider2"></div>
 

--- a/index.html
+++ b/index.html
@@ -1407,6 +1407,19 @@
 
                         <div class="ttcont">
                             <div class="texts">
+                                <div class="bigText" id="hideSearch">Hide Search</div>
+                                <div class="infoText" id="hideSearchInfo">
+                                    Hide the search bar and search engine sections entirely
+                                </div>
+                            </div>
+                            <label class="switch">
+                                <input id="hideSearchCheckbox" type="checkbox">
+                                <span class="toggle"></span>
+                            </label>
+                        </div>
+
+                        <div class="ttcont">
+                            <div class="texts">
                                 <div class="bigText" id="hideSearchWith">Hide Search Engines</div>
                                 <div class="infoText" id="hideSearchWithInfo">Switch between search engines by clicking
                                     its icon
@@ -1561,18 +1574,6 @@
                             </div>
                         </div>
 
-                        <div class="ttcont">
-                            <div class="texts">
-                                <div class="bigText" id="hideSearch">Hide Search</div>
-                                <div class="infoText" id="hideSearchInfo">
-                                    Hide the search bar and search engine sections entirely
-                                </div>
-                            </div>
-                            <label class="switch">
-                                <input id="hideSearchCheckbox" type="checkbox">
-                                <span class="toggle"></span>
-                            </label>
-                        </div>
                     </div>
                     <div class="divider" id="divider2"></div>
 

--- a/locales/en.js
+++ b/locales/en.js
@@ -60,6 +60,8 @@ const en = {
     "motivationalQuotesInfo": "Show quotes below the searchbar",
     "search_suggestions_button": "Search Suggestions",
     "search_suggestions_text": "Enable search suggestions",
+    "hideSearch": "Hide Search",
+    "hideSearchInfo": "Hide the search bar and search engine sections entirely",
 
     // Proxy
     "useproxytitletext": "Proxy Bypass",

--- a/scripts/quotes.js
+++ b/scripts/quotes.js
@@ -285,6 +285,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const motivationalQuotesCont = document.getElementById("motivationalQuotesCont");
     const motivationalQuotesCheckbox = document.getElementById("motivationalQuotesCheckbox");
     const searchWithContainer = document.getElementById("search-with-container");
+    const hideSearchCheckbox = document.getElementById("hideSearchCheckbox")
 
     // Load states from localStorage
     hideSearchWith.checked = localStorage.getItem("showShortcutSwitch") === "true";
@@ -297,12 +298,13 @@ document.addEventListener("DOMContentLoaded", () => {
     const updateMotivationalQuotesState = () => {
         const isHideSearchWithEnabled = hideSearchWith.checked;
         const isMotivationalQuotesEnabled = motivationalQuotesCheckbox.checked;
+        const isHideSearchChecked = hideSearchCheckbox.checked;
 
         // Save state to localStorage
         localStorage.setItem("motivationalQuotesVisible", isMotivationalQuotesEnabled);
 
         // Handle visibility based on settings
-        if (!isHideSearchWithEnabled) {
+        if (!isHideSearchWithEnabled && !isHideSearchChecked) {
             quotesToggle.classList.add("inactive");
             motivationalQuotesCont.style.display = "none";
             clearQuotesStorage();
@@ -311,7 +313,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
         // Update UI visibility
         quotesToggle.classList.remove("inactive");
-        searchWithContainer.style.display = isMotivationalQuotesEnabled ? "none" : "flex";
+        searchWithContainer.style.display = (isMotivationalQuotesEnabled || isHideSearchChecked) ? "none" : "flex";
         motivationalQuotesCont.style.display = isMotivationalQuotesEnabled ? "flex" : "none";
 
         // Load quotes if motivational quotes are enabled
@@ -328,6 +330,10 @@ document.addEventListener("DOMContentLoaded", () => {
     // Event Listeners
     hideSearchWith.addEventListener("change", () => {
         searchWithContainer.style.display = "flex";
+        updateMotivationalQuotesState();
+    });
+
+    hideSearchCheckbox.addEventListener("change", () => {
         updateMotivationalQuotesState();
     });
 

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -381,6 +381,41 @@ hideSearchWith.addEventListener("change", (e) => {
     sortDropdown();
 });
 
+// Hiding search bar and search engine container based on saved preference
+function handleSearchVisibility(isChecked) {
+    const searchBar = document.getElementById("searchbar");
+    const searchWithContainer = document.getElementById("search-with-container"); 
+
+    // show/hide search bar
+    searchBar.style.display = isChecked ? "none" : "block";
+
+    // also take "showShortcutSwitch" into account while showing/hiding search with container
+    const isShortCutSwitchEnabled = localStorage.getItem("showShortcutSwitch").toString() === "true";
+    searchWithContainer.style.display = (isChecked || isShortCutSwitchEnabled) ? "none" : "flex"
+
+    // disable the shortcut switch if search is hidden
+    const shortcutSwitchParent = document.getElementById("hideSearchWith")?.parentElement?.parentElement
+    if(isChecked) shortcutSwitchParent.classList.add("inactive");
+    else shortcutSwitchParent.classList.remove("inactive");
+}
+
+const hideSearchCheckbox = document.getElementById("hideSearchCheckbox")
+hideSearchCheckbox.addEventListener("change", (e) => {
+    const isChecked = e.target.checked;
+
+    handleSearchVisibility(isChecked);
+
+    // update localStorage
+    localStorage.setItem("hideSearch", isChecked);
+})
+
+// Initialize search visibility based on saved preference
+if (localStorage.getItem("hideSearch")) {
+    const isSearchHidden = localStorage.getItem("hideSearch").toString() === "true";
+    hideSearchCheckbox.checked = isSearchHidden;
+    handleSearchVisibility(isSearchHidden);
+}
+
 // Intialize shortcut switch
 if (localStorage.getItem("showShortcutSwitch")) {
     const isShortCutSwitchEnabled = localStorage.getItem("showShortcutSwitch").toString() === "true";

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -388,8 +388,8 @@ function handleSearchVisibility(isChecked) {
 
     // show/hide search bar
     // searchBar.style.display = isChecked ? "none" : "block";
-    if (isChecked) searchBar.classList.add("hiddenByOption")
-    else searchBar.classList.remove("hiddenByOption")
+    if (isChecked) searchBar.classList.add("hidden-by-option")
+    else searchBar.classList.remove("hidden-by-option")
 
     // also take "showShortcutSwitch" into account while showing/hiding search with container
     const isShortCutSwitchEnabled = localStorage.getItem("showShortcutSwitch")?.toString() === "true";

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -390,7 +390,7 @@ function handleSearchVisibility(isChecked) {
     searchBar.style.display = isChecked ? "none" : "block";
 
     // also take "showShortcutSwitch" into account while showing/hiding search with container
-    const isShortCutSwitchEnabled = localStorage.getItem("showShortcutSwitch").toString() === "true";
+    const isShortCutSwitchEnabled = localStorage.getItem("showShortcutSwitch")?.toString() === "true";
     searchWithContainer.style.display = (isChecked || isShortCutSwitchEnabled) ? "none" : "flex"
 
     // disable the shortcut switch if search is hidden

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -384,10 +384,12 @@ hideSearchWith.addEventListener("change", (e) => {
 // Hiding search bar and search engine container based on saved preference
 function handleSearchVisibility(isChecked) {
     const searchBar = document.getElementById("searchbar");
-    const searchWithContainer = document.getElementById("search-with-container"); 
+    const searchWithContainer = document.getElementById("search-with-container");
 
     // show/hide search bar
-    searchBar.style.display = isChecked ? "none" : "block";
+    // searchBar.style.display = isChecked ? "none" : "block";
+    if (isChecked) searchBar.classList.add("hiddenByOption")
+    else searchBar.classList.remove("hiddenByOption")
 
     // also take "showShortcutSwitch" into account while showing/hiding search with container
     const isShortCutSwitchEnabled = localStorage.getItem("showShortcutSwitch")?.toString() === "true";
@@ -395,8 +397,21 @@ function handleSearchVisibility(isChecked) {
 
     // disable the shortcut switch if search is hidden
     const shortcutSwitchParent = document.getElementById("hideSearchWith")?.parentElement?.parentElement
-    if(isChecked) shortcutSwitchParent.classList.add("inactive");
+    if (isChecked) shortcutSwitchParent.classList.add("inactive");
     else shortcutSwitchParent.classList.remove("inactive");
+
+    // enable/disable the hide microphone icon
+    const hideMicParent = document.getElementById("micIconTitle")?.parentElement?.parentElement
+    if (isChecked) hideMicParent.classList.add("inactive");
+    else hideMicParent.classList.remove("inactive");
+
+    // uncheck and hide the search suggestion option as well
+    const searchSuggestionInput = document.getElementById("searchsuggestionscheckbox")
+    const searchSuggestionParent = searchSuggestionInput?.parentElement?.parentElement
+    if (isChecked) {
+        searchSuggestionInput.checked = false
+        searchSuggestionParent.classList.add("inactive")
+    } else searchSuggestionParent.classList.remove("inactive")
 }
 
 const hideSearchCheckbox = document.getElementById("hideSearchCheckbox")

--- a/style.css
+++ b/style.css
@@ -2005,15 +2005,14 @@ body[data-bg="wallpaper"] .searchbar {
 	margin-inline-start: 16px;
 }
 
-.searchbar.hiddenByOption {
+.searchbar.hidden-by-option {
 	display: none;
 	opacity: 1;
 }
 
 @media screen and (max-width: 500px) {
-	.searchbar.hiddenByOption {
+	.searchbar.hidden-by-option {
 		display: block;
-
 		opacity: 0;
 	}
 }

--- a/style.css
+++ b/style.css
@@ -3496,7 +3496,7 @@ input:checked + .toggle:before {
 	appearance: none;
 	-moz-appearance: none;
 	cursor: pointer;
-	padding-inline-start: 14px;
+	padding-inline-start: 18px;
 	font-size: 0.82rem;
 	@-moz-document url-prefix() {
 		/* Scrollbar styles for Firefox */

--- a/style.css
+++ b/style.css
@@ -2005,6 +2005,19 @@ body[data-bg="wallpaper"] .searchbar {
 	margin-inline-start: 16px;
 }
 
+.searchbar.hiddenByOption {
+	display: none;
+	opacity: 1;
+}
+
+@media screen and (max-width: 500px) {
+	.searchbar.hiddenByOption {
+		display: block;
+
+		opacity: 0;
+	}
+}
+
 .searchbar-content {
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
## 📌 Description

Added a new setting item to hide the search section entirely(as requested on https://github.com/prem-k-r/MaterialYouNewTab/issues/51).
Enabling this will 
- hide the search bar and the search engine section 
- show the motivational element (unless it is hidden)
- disable the "Hide Search Engines" setting

## 🎨 Visual Changes (Screenshots / Videos)


https://github.com/user-attachments/assets/a5d57cbc-d368-4a36-8ca0-6976a9c56382


## 🔗 Related Issues

- Closes https://github.com/prem-k-r/MaterialYouNewTab/issues/51

## ✅ Checklist

<!-- Tip: To mark a checklist item as complete, replace [ ] with [x] -->

- [x] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] My code follows the project's coding style and conventions.
- [x] I have tested my changes thoroughly to ensure expected behavior.
- [x] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [x] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [x] I have updated the [CHANGELOG.md](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
* **New Features**
  * Added a new "Hide Search" setting in Settings that hides the search bar and the "Search With" (search engines) section entirely. The preference is persisted to localStorage and applied on load.

* **Behavioral details**
  * When "Hide Search" is enabled:
    * search bar, search-with container, shortcut switch, mic icon, and search suggestions controls are hidden/disabled.
    * the existing "Hide Search Engines" option is disabled/synchronized.
    * motivational quotes remain visible unless the separate "Motivational Quotes" setting is disabled.
  * Visibility is coordinated in scripts/search.js and scripts/quotes.js; an event listener updates UI state when the new checkbox changes.

* **UI / i18n / styling**
  * index.html: added the new settings block (checkbox id hideSearchCheckbox) in the Search settings.
  * locales/en.js: added translation keys hideSearch and hideSearchInfo.
  * style.css: added .searchbar.hiddenByOption and a responsive rule to adjust small-screen behavior (<=500px) to preserve layout while hiding.

* **Changelog**
  * CHANGELOG.md updated to note the new setting under Unreleased -> Added.

* **Notes / outstanding issues**
  * PR is marked work-in-progress / changes-requested. Reviewer reported:
    * inactive hide mic option,
    * unchecked/inactive search suggestions option,
    * layout issue at screen widths ≤500px (weather pill moves up).
  * Contributor acknowledged the issues and intends to push fixes; visual evidence is attached in the PR and compatibility across Chrome/Firefox was tested.

* **Files touched (high level)**
  * index.html, locales/en.js, scripts/search.js, scripts/quotes.js, style.css, CHANGELOG.md
<!-- end of auto-generated comment: release notes by coderabbit.ai -->