### PR TITLE
Fade out loading screen and preload wallpaper

### DIFF
--- a/scripts/preload.js
+++ b/scripts/preload.js
@@ -7,4 +7,23 @@
  */
 
 // Set Loading Screen Color before Everything Loads
-document.documentElement.style.setProperty('--Loading-Screen-Color', localStorage.getItem('LoadingScreenColor') || "#bbd6fd");
+document.documentElement.style.setProperty('--Loading-Screen-Color', localStorage.getItem('LoadingScreenColor') || "#000000ff");
+
+// Early dark mode detection to prevent light→dark flash
+// The CSS dark mode filter (invert + hue-rotate) normally depends on DOM elements
+// that don't exist yet. Pre-apply the filter on <html> so the loading screen
+// matches the dark mode appearance from the first paint.
+(function () {
+    const preferredTheme = localStorage.getItem('preferredTheme');
+    const selectedTheme = localStorage.getItem('selectedTheme');
+    const savedBgType = localStorage.getItem('bgType');
+    const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+    const isDarkMode = preferredTheme === 'dark' || (preferredTheme === 'system' && systemDark);
+    const isColorBg = savedBgType !== 'wallpaper'; // default to color if not saved
+    const isBlackTheme = selectedTheme === 'dark';
+
+    if (isDarkMode && isColorBg && !isBlackTheme) {
+        document.documentElement.classList.add('early-dark-filter');
+    }
+})();

--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -84,6 +84,20 @@ syncThemeChange(systemTheme);
     initializeThemeMode();
 })();
 
+// Hide loading screen with smooth fade-out
+function hideLoadingScreen() {
+    const loadingScreen = document.getElementById("LoadingScreen");
+    if (!loadingScreen || loadingScreen.classList.contains("fade-out")) return;
+    loadingScreen.classList.add("fade-out");
+    loadingScreen.addEventListener("transitionend", () => {
+        loadingScreen.style.display = "none";
+    }, { once: true });
+    // Fallback in case transitionend doesn't fire
+    setTimeout(() => {
+        loadingScreen.style.display = "none";
+    }, 500);
+}
+
 document.addEventListener("DOMContentLoaded", () => {
     // Check for custom color
     const storedCustomColor = localStorage.getItem(customThemeStorageKey);
@@ -106,8 +120,20 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 
-    // Remove Loading Screen when the DOM and the theme has loaded
-    document.getElementById("LoadingScreen").style.display = "none";
+    // Signal that theme is ready; loading screen will be hidden
+    // once both theme and wallpaper are ready
+    window._themeReady = true;
+    if (window._wallpaperReady) {
+        hideLoadingScreen();
+    }
+
+    // Safety: ensure loading screen is hidden even if wallpaper never signals
+    setTimeout(() => {
+        if (!window._wallpaperReady) {
+            window._wallpaperReady = true;
+            hideLoadingScreen();
+        }
+    }, 3000);
 
     // Stop blinking of some elements when the page is reloaded
     setTimeout(() => {

--- a/scripts/wallpaper.js
+++ b/scripts/wallpaper.js
@@ -127,6 +127,32 @@ function toggleBackgroundType(hasWallpaper) {
     document.body.setAttribute("data-bg", hasWallpaper ? "wallpaper" : "color");
 }
 
+// Signal that wallpaper is ready and trigger loading screen hide if theme is also ready
+function signalWallpaperReady() {
+    window._wallpaperReady = true;
+    if (window._themeReady) {
+        hideLoadingScreen();
+    }
+}
+
+// Helper to preload and decode an image before applying it as background
+function preloadAndApplyBackground(imageUrl) {
+    return new Promise((resolve) => {
+        const img = new Image();
+        img.src = imageUrl;
+        img.decode().then(() => {
+            document.body.style.setProperty("--bg-image", `url(${imageUrl})`);
+            toggleBackgroundType(true);
+            resolve();
+        }).catch(() => {
+            // Fallback: apply even if decode fails
+            document.body.style.setProperty("--bg-image", `url(${imageUrl})`);
+            toggleBackgroundType(true);
+            resolve();
+        });
+    });
+}
+
 // Check and update image on page load
 function checkAndUpdateImage() {
     loadImageAndDetails()
@@ -137,6 +163,7 @@ function checkAndUpdateImage() {
             // No image or invalid data
             if (!blob || !savedTimestamp || isNaN(lastUpdate)) {
                 toggleBackgroundType(false);
+                signalWallpaperReady();
                 return;
             }
 
@@ -144,26 +171,30 @@ function checkAndUpdateImage() {
             const imageUrl = URL.createObjectURL(blob);
 
             if (imageType === "upload") {
-                document.body.style.setProperty("--bg-image", `url(${imageUrl})`);
-                toggleBackgroundType(true);
+                preloadAndApplyBackground(imageUrl).then(() => {
+                    signalWallpaperReady();
+                });
                 return;
             }
 
             if (lastUpdate.toDateString() !== now.toDateString()) {
                 // Refresh random image if a new day
-                applyRandomImage(false);
+                applyRandomImage(false).then(() => {
+                    signalWallpaperReady();
+                });
             } else {
                 // Reapply the saved random image
-                document.body.style.setProperty("--bg-image", `url(${imageUrl})`);
-                toggleBackgroundType(true);
+                preloadAndApplyBackground(imageUrl).then(() => {
+                    signalWallpaperReady();
+                    // Clean up the Blob URL after setting the background
+                    setTimeout(() => URL.revokeObjectURL(imageUrl), 1500);
+                });
             }
-
-            // Clean up the Blob URL after setting the background
-            setTimeout(() => URL.revokeObjectURL(imageUrl), 1500);
         })
         .catch((error) => {
             console.error("Error loading image details:", error);
             toggleBackgroundType(false);
+            signalWallpaperReady();
         });
 }
 

--- a/scripts/wallpaper.js
+++ b/scripts/wallpaper.js
@@ -124,7 +124,10 @@ async function applyRandomImage(showConfirmation = true) {
 
 // Function to update the background type attribute
 function toggleBackgroundType(hasWallpaper) {
-    document.body.setAttribute("data-bg", hasWallpaper ? "wallpaper" : "color");
+    const bgType = hasWallpaper ? "wallpaper" : "color";
+    document.body.setAttribute("data-bg", bgType);
+    localStorage.setItem("bgType", bgType);
+    document.documentElement.classList.remove("early-dark-filter");
 }
 
 // Signal that wallpaper is ready and trigger loading screen hide if theme is also ready

--- a/style.css
+++ b/style.css
@@ -225,8 +225,14 @@ body {
    Prevents light→dark flash by pre-applying the invert filter on <html>.
    Removed by wallpaper.js once the proper CSS selectors can take over. */
 html.early-dark-filter {
-	filter: invert(1) hue-rotate(180deg);
 	-webkit-filter: invert(1) hue-rotate(180deg);
+	filter: invert(1) hue-rotate(180deg);
+
+	& #darkTheme,
+	& .favicon {
+		-webkit-filter: invert(1) hue-rotate(180deg);
+		filter: invert(1) hue-rotate(180deg);
+	}
 }
 
 /* Apply dark mode when: Dark Mode is selected manually, OR System Theme is selected */
@@ -238,13 +244,13 @@ html:has(
 			.menuBar
 			.themeSegment[data-active="system"]
 	):not(:has(#darkTheme:checked)) {
-	filter: invert(1) hue-rotate(180deg);
 	-webkit-filter: invert(1) hue-rotate(180deg);
+	filter: invert(1) hue-rotate(180deg);
 
 	& #darkTheme,
 	& .favicon {
-		filter: invert(1) hue-rotate(180deg);
 		-webkit-filter: invert(1) hue-rotate(180deg);
+		filter: invert(1) hue-rotate(180deg);
 	}
 
 	& .menuBar,
@@ -276,13 +282,13 @@ body[data-bg="wallpaper"][sysTheme="systemDark"]:has(
 		.menuBar .themeSegment[data-active="system"]
 	):not(:has(#darkTheme:checked))
 	:is(.menuCont, .bookmark-sidebar) {
-	filter: invert(1) hue-rotate(180deg);
 	-webkit-filter: invert(1) hue-rotate(180deg);
+	filter: invert(1) hue-rotate(180deg);
 
 	& #darkTheme,
 	& .favicon {
-		filter: invert(1) hue-rotate(180deg);
 		-webkit-filter: invert(1) hue-rotate(180deg);
+		filter: invert(1) hue-rotate(180deg);
 	}
 
 	--whitishColor-blue: #f2f2f2;

--- a/style.css
+++ b/style.css
@@ -221,6 +221,14 @@ body {
 	margin: 0;
 }
 
+/* Early dark mode filter applied by preload.js before DOM elements exist.
+   Prevents light→dark flash by pre-applying the invert filter on <html>.
+   Removed by wallpaper.js once the proper CSS selectors can take over. */
+html.early-dark-filter {
+	filter: invert(1) hue-rotate(180deg);
+	-webkit-filter: invert(1) hue-rotate(180deg);
+}
+
 /* Apply dark mode when: Dark Mode is selected manually, OR System Theme is selected */
 html:has(body[data-bg="color"] .menuBar .themeSegment[data-active="dark"]):not(
 		:has(#darkTheme:checked)

--- a/style.css
+++ b/style.css
@@ -4330,6 +4330,13 @@ body[data-bg="wallpaper"] .dropdown-content {
 	width: 100%;
 	inset: 0;
 	z-index: 99999;
+	opacity: 1;
+	transition: opacity 0.3s ease;
+}
+
+#LoadingScreen.fade-out {
+	opacity: 0;
+	pointer-events: none;
 }
 
 .toggleTextsCont .ttcont:has(#hideWeatherBox) {


### PR DESCRIPTION
Add smooth fade-out handling for the loading screen and coordinate hiding between theme and wallpaper readiness. Introduce hideLoadingScreen() with transitionend and fallback timeout, and use global flags (_themeReady/_wallpaperReady) so loading screen is only removed once both are ready (with a 3s safety fallback). In wallpaper.js add signalWallpaperReady(), preloadAndApplyBackground() to decode images before applying, and call these from checkAndUpdateImage/applyRandomImage flows; ensure Blob URL cleanup. Add CSS rules for #LoadingScreen fade-out transition and pointer-events handling.## 📌 Description

<!-- Please provide a clear and concise description of the changes introduced in this PR and their purpose. -->

## 🎨 Visual Changes (Screenshots / Videos)

<!-- If applicable, attach relevant screenshots or screen recordings showcasing the modifications. -->

## 🔗 Related Issues

- Closes #<issue_number> <!-- if this PR fixes an issue -->
- Related to #<issue_number> <!-- if applicable -->

## ✅ Checklist

<!-- Tip: To mark a checklist item as complete, replace [ ] with [x] -->

- [ ] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CONTRIBUTING.md).
- [ ] My code follows the project's coding style and conventions.
- [ ] I have tested my changes thoroughly to ensure expected behavior.
- [ ] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [ ] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [ ] I have updated the [CHANGELOG.md](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.
Add smooth fade-out handling for the loading screen and coordinate hiding between theme and wallpaper readiness. Introduce hideLoadingScreen() with transitionend and fallback timeout, and use global flags (_themeReady/_wallpaperReady) so loading screen is only removed once both are ready (with a 3s safety fallback). In wallpaper.js add signalWallpaperReady(), preloadAndApplyBackground() to decode images before applying, and call these from checkAndUpdateImage/applyRandomImage flows; ensure Blob URL cleanup. Add CSS rules for #LoadingScreen fade-out transition and pointer-events handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR prevents theme and wallpaper flashes on page load by implementing coordinated fade-out of the loading screen and preloading wallpaper images before they are applied. The changes introduce readiness synchronization between theme and wallpaper modules, early dark-mode detection, and image preload/decode workflows.

## Key Changes

### Loading Screen Synchronization
- Added `hideLoadingScreen()` helper in `scripts/theme.js` that fades out `#LoadingScreen` by adding a `fade-out` class with a 0.3s CSS transition, hides the element on `transitionend`, and includes a 500ms fallback timeout
- Introduced global readiness flags (`window._themeReady` and `window._wallpaperReady`) so the loading screen is only removed once both theme and wallpaper modules signal readiness
- Added 3-second safety fallback that forces removal if wallpaper readiness is not signaled in time

### Wallpaper Preloading
- Added `preloadAndApplyBackground(imageUrl)` in `scripts/wallpaper.js` that decodes images via `img.decode()` before applying them, with fallback handling for decode failures
- Introduced `signalWallpaperReady()` that coordinates with the theme module to conditionally hide the loading screen once both are ready
- Updated `checkAndUpdateImage()` control flow to use preload for stored uploads and re-applied random images, with proper Blob URL cleanup

### Early Dark-Mode Detection
- Added dark-mode detection in `scripts/preload.js` that reads stored theme preference and checks system `prefers-color-scheme` before initial page paint
- Conditionally applies `early-dark-filter` class to document root to prevent light-to-dark flashes during first render
- Updated `#LoadingScreen` color variable from `#bbd6fd` to `#000000ff`

### CSS Enhancements
- Added `html.early-dark-filter` rule with `filter: invert(1) hue-rotate(180deg)` to prevent early flash
- Updated `#LoadingScreen` with `opacity: 1` and `transition: opacity 0.3s ease`
- Added `#LoadingScreen.fade-out` with `opacity: 0` and `pointer-events: none` for fade-out animation
- Consolidated dark-mode filter application to consistently use `invert(1) hue-rotate(180deg)` with webkit prefixes

### Storage Persistence
- Extended `toggleBackgroundType` in `scripts/wallpaper.js` to persist selected background type to `localStorage` as `bgType`
- Removes `early-dark-filter` class when background type is toggled

## Technical Details
- Loading screen removal waits for both `_themeReady` and `_wallpaperReady` signals before executing fade-out
- Image preloading uses `decode()` method for safe decoding with fallback behavior on failure
- Three-second safety timeout ensures loading screen removal even if wallpaper module fails to signal readiness
- Proper cleanup of Blob URLs only in branches where images are explicitly revoked to prevent resource leaks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->