### PR TITLE
feat: Added smooth wallpaper fade-in and fixed the widget transparency delay on page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project partially follows [Semantic Versioning](https://semver.org/spec
 - Improved fallback behavior of shortcut icons to first-letter icons when custom icons fail to load or when offline ([@prem-k-r](https://github.com/prem-k-r)) ([#187](https://github.com/prem-k-r/MaterialYouNewTab/pull/187/))
 - Disabled dragging for weather and location icons ([@anndiy](https://github.com/anndiy)) ([#183](https://github.com/prem-k-r/MaterialYouNewTab/pull/183))
 - Added support for right-click to access AI Tools settings ([@prem-k-r](https://github.com/prem-k-r)) ([#210](https://github.com/prem-k-r/MaterialYouNewTab/pull/210/))
+- Added smooth wallpaper fade-in and fixed the widget transparency delay on page load. ([@prem-k-r](https://github.com/prem-k-r)) ([#217](https://github.com/prem-k-r/MaterialYouNewTab/pull/217/))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,14 @@ and this project partially follows [Semantic Versioning](https://semver.org/spec
 - Improved fallback behavior of shortcut icons to first-letter icons when custom icons fail to load or when offline ([@prem-k-r](https://github.com/prem-k-r)) ([#187](https://github.com/prem-k-r/MaterialYouNewTab/pull/187/))
 - Disabled dragging for weather and location icons ([@anndiy](https://github.com/anndiy)) ([#183](https://github.com/prem-k-r/MaterialYouNewTab/pull/183))
 - Added support for right-click to access AI Tools settings ([@prem-k-r](https://github.com/prem-k-r)) ([#210](https://github.com/prem-k-r/MaterialYouNewTab/pull/210/))
-- Added smooth wallpaper fade-in and fixed the widget transparency delay on page load. ([@prem-k-r](https://github.com/prem-k-r)) ([#217](https://github.com/prem-k-r/MaterialYouNewTab/pull/217/))
+- Added smooth wallpaper fade-in on page load ([@prem-k-r](https://github.com/prem-k-r)) ([#217](https://github.com/prem-k-r/MaterialYouNewTab/pull/217/))
 
 ### Fixed
 
 - Fixed an issue where rapid clicks on the AI Tools icon caused race conditions, leading to inconsistent shortcuts panel visibility. ([@prem-k-r](https://github.com/prem-k-r)) ([#118](https://github.com/prem-k-r/MaterialYouNewTab/pull/118))
 - Fixed shortcut name and URLs hover behavior by replacing ellipsis with clipped text for improved readability ([@prem-k-r](https://github.com/prem-k-r)) ([283f78d](https://github.com/prem-k-r/MaterialYouNewTab/pull/199/changes/283f78d6e4b202a075ca3d670c1b30cbc701c3a4))
 - Fixed wallpaper disappearing on load due to blob URL being revoked too early ([@prem-k-r](https://github.com/prem-k-r)) ([#209](https://github.com/prem-k-r/MaterialYouNewTab/pull/209))
+- Fixed widget transparency delay on page load when wallpaper is set ([@prem-k-r](https://github.com/prem-k-r)) ([#217](https://github.com/prem-k-r/MaterialYouNewTab/pull/217/))
 
 ### Localized
 

--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
 <body>
     <!-- --------------------- Loading Screen Starting --------------------- -->
     <img src="./images/Loading.png" id="LoadingScreen" fetchpriority="high" />
+    <img id="bg-img" alt="" />
 
     <!-- --------------------- ToDo List Setup Starting --------------------- -->
     <!-- ToDo Icon -->

--- a/manifest(firefox).json
+++ b/manifest(firefox).json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "MYNT: Material You New Tab",
-	"version": "3.3.613",
+	"version": "3.3.722",
 	"description": "A Simple New Tab (browser's home page) inspired by Google's 'Material You' design.",
 	"permissions": [
 		"search",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "MYNT: Material You New Tab",
-	"version": "3.3.613",
+	"version": "3.3.722",
 	"description": "A Simple New Tab (browser's home page) inspired by Google's 'Material You' design.",
 	"permissions": ["search"],
 	"optional_permissions": ["bookmarks", "favicon"],

--- a/scripts/wallpaper.js
+++ b/scripts/wallpaper.js
@@ -15,16 +15,31 @@ const imageTypeKey = "imageType"; // Key to store the type of image ("random" or
 
 let currentBgUrl = null;
 
+if (localStorage.getItem("hasWallpaper") === "true") {
+    toggleBackgroundType(true);
+}
+
 // To set background image using a Blob
 function setBackground(blob) {
+    const img = document.getElementById("bg-img");
     const previousUrl = currentBgUrl;
     const newUrl = URL.createObjectURL(blob);
-    currentBgUrl = newUrl;
-    document.body.style.setProperty("--bg-image", `url(${newUrl})`);
+
     toggleBackgroundType(true);
-    if (previousUrl) {
-        URL.revokeObjectURL(previousUrl);
-    }
+    localStorage.setItem("hasWallpaper", "true");
+
+    img.classList.remove("bg-visible"); // reset opacity for the fade-in
+
+    img.onload = () => {
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                currentBgUrl = newUrl;
+                img.classList.add("bg-visible"); // fade in only the image
+                if (previousUrl) URL.revokeObjectURL(previousUrl);
+            });
+        });
+    };
+    img.src = newUrl;
 }
 
 // Open IndexedDB database
@@ -134,6 +149,7 @@ function checkAndUpdateImage() {
             const lastUpdate = new Date(savedTimestamp);
 
             if (!blob || !savedTimestamp || isNaN(lastUpdate)) {
+                localStorage.removeItem("hasWallpaper");
                 toggleBackgroundType(false);
                 return;
             }
@@ -152,6 +168,7 @@ function checkAndUpdateImage() {
         })
         .catch((error) => {
             console.error("Error loading image details:", error);
+            localStorage.removeItem("hasWallpaper");
             toggleBackgroundType(false);
         });
 }
@@ -173,11 +190,15 @@ document.getElementById("clearImage").addEventListener("click", async function (
         if (await confirmPrompt(confirmationMessage)) {
             try {
                 await clearImageFromIndexedDB();
+                localStorage.removeItem("hasWallpaper");
+
+                const img = document.getElementById("bg-img");
+                img.classList.remove("bg-visible");
+
                 if (currentBgUrl) {
                     URL.revokeObjectURL(currentBgUrl);
                     currentBgUrl = null;
                 }
-                document.body.style.removeProperty("--bg-image");
                 toggleBackgroundType(false);
             } catch (error) {
                 console.error(error);

--- a/style.css
+++ b/style.css
@@ -212,13 +212,25 @@ body {
 	width: 100%;
 	min-height: 100vh;
 	overflow: auto;
-	background-image: var(--bg-image, none);
-	background-size: cover;
-	background-repeat: no-repeat;
-	background-position: center;
-	background-attachment: fixed;
-	height: 100%; /* Ensure the image fits the viewport height */
+	height: 100%;
 	margin: 0;
+}
+
+#bg-img {
+	position: fixed;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	object-position: center;
+	z-index: -1;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 0.3s ease;
+}
+
+#bg-img.bg-visible {
+	opacity: 1;
 }
 
 /* Apply dark mode when: Dark Mode is selected manually, OR System Theme is selected */


### PR DESCRIPTION
Replace CSS background-image with a fixed <img id="bg-img"> element for wallpapers. Adds the DOM element in index.html and styles it for full-viewport coverage and an opacity-based fade. Update wallpaper.js to set the image via URL.createObjectURL, handle load-based fade-in, revoke previous object URLs, and persist state with localStorage.hasWallpaper. Also remove the persisted flag on errors or when clearing the image and adjust toggle logic accordingly.

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added smooth wallpaper fade-in using a fixed, viewport-covering background image.
- Fixed widget transparency delays during page load when a wallpaper is configured.
- Improved wallpaper state persistence and cleanup, including object URL revocation and error handling.
- Updated changelog and bumped extension versions to `3.3.722`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->