### PR TITLE
fix: smooth continuous second-hand motion with millisecond precision …

### DIFF
--- a/scripts/clock.js
+++ b/scripts/clock.js
@@ -213,21 +213,30 @@ async function initializeClock() {
     function updateanalogclock() {
         var currentTime = new Date();
         var currentSeconds = currentTime.getSeconds();
+        var currentMilliseconds = currentTime.getMilliseconds();
         var currentMinutes = currentTime.getMinutes();
         var currentHours = currentTime.getHours();
 
         // Calculate the new rotation values
-        let newSecondRotation = currentSeconds * 6; // 6° per second
+        let newSecondRotation = (currentSeconds + (currentMilliseconds / 1000)) * 6; // 6° per second with millisecond precision
         let newMinuteRotation = currentMinutes * 6 + (currentSeconds / 10); // 6° per minute + adjustment for seconds
         let newHourRotation = (30 * (currentHours % 12) + currentMinutes / 2); // 30° per hour + adjustment for minutes, 12-hour cycle
 
         // Define reset conditions
-        const secondReset = currentSeconds === 0;
         const minuteReset = currentMinutes === 0 && currentSeconds === 0;
         const hourReset = currentHours % 12 === 0 && currentMinutes === 0 && currentSeconds === 0;
 
-        // Update each hand using the helper function
-        cumulativeSecondRotation = updateHandRotation("second", newSecondRotation, cumulativeSecondRotation, secondReset);
+        // Update second hand continuously while preserving forward motion across minute boundaries
+        const currentSecondTurn = Math.floor(cumulativeSecondRotation / 360) * 360;
+        let continuousSecondRotation = currentSecondTurn + newSecondRotation;
+        if (!isFirstLoad && continuousSecondRotation < cumulativeSecondRotation)
+            continuousSecondRotation += 360;
+
+        cumulativeSecondRotation = continuousSecondRotation;
+        document.getElementById("second").style.transition = "transform 0.05s linear";
+        document.getElementById("second").style.transform = `rotate(${cumulativeSecondRotation}deg)`;
+
+        // Keep existing smooth behavior for minute and hour hands
         cumulativeMinuteRotation = updateHandRotation("minute", newMinuteRotation, cumulativeMinuteRotation, minuteReset);
         cumulativeHourRotation = updateHandRotation("hour", newHourRotation, cumulativeHourRotation, hourReset);
 
@@ -407,7 +416,7 @@ async function initializeClock() {
     // Function to start the analog clock
     function startAnalogClock() {
         if (!analogIntervalId) { // Only set interval if not already set
-            analogIntervalId = setInterval(updateanalogclock, 500);
+            analogIntervalId = setInterval(updateanalogclock, 50);
         }
     }
 


### PR DESCRIPTION
## Summary
This PR fixes the analog clock second-hand behavior reported in #102.

The second hand now moves continuously (instead of stepping once per second), uses millisecond precision, and keeps forward continuity when crossing minute boundaries (`59.xs -> 0.xs`) to avoid backward visual jumps.

## Root cause
- The previous implementation relied on second-level granularity for second-hand rotation.
- Refresh cadence and rotation application caused visible stepping.
- At minute rollover, direct 0–360 mapping could create a backward-looking animation.

## Changes made
- File changed: `scripts/clock.js` only.
- Read `currentMilliseconds` and compute:
  - `newSecondRotation = (currentSeconds + (currentMilliseconds / 1000)) * 6`
- Keep second-hand rotation continuous using cumulative forward rotation logic across turns.
- Apply direct second-hand transform update with a short linear transition:
  - `transform 0.05s linear`
- Increase analog update interval from `500ms` to `50ms`.
- Keep minute/hour hand logic via existing `updateHandRotation` flow (no refactor).

## Why this is minimal and safe
- Single-file, scoped change.
- No dependency/version updates.
- No HTML/CSS/layout modifications.
- No route/API/contract changes.
- Existing behavior for digital clock and other features remains intact.

## Validation
- Syntax check:
  - `node --check scripts/clock.js` ✅
- Manual verification:
  1. Enable analog clock.
  2. Observe second hand for smooth motion.
  3. Observe transition around minute rollover (`59.xs -> 0.xs`); it should continue forward without visual backward jump.

## Notes
- This is a functional bug fix (not chore), aligned with issue #102.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes the analog clock's second-hand animation to display smooth continuous motion with proper minute-boundary handling.

## Changes

**scripts/clock.js**

- **Second-hand millisecond precision**: Updated second-hand rotation calculation from using only `seconds` to `(seconds + milliseconds/1000) * 6`, enabling sub-second granularity and smoother visual motion.

- **Increased update frequency**: Changed the analog clock refresh interval from 500ms to 50ms via `setInterval(updateanalogclock, 50)`, reducing perceived stepping artifacts.

- **Smooth second-hand animation**: Applied a short linear CSS transition (`transform 0.05s linear`) to the second hand, replacing the previous approach and creating fluid motion between updates.

- **Cumulative forward rotation logic**: Implemented logic to compute continuous second-hand rotation across minute boundaries by tracking cumulative rotation (`cumulativeSecondRotation`) and detecting when the computed angle would represent a backward motion, then adding 360° to preserve forward continuity (preventing a visual backward jump at 59.x → 0.x seconds).

- **Preserved minute/hour hand behavior**: The minute and hour hands continue to use the existing `updateHandRotation()` function with its 1-second ease transition, ensuring no change to their animation behavior.

## Details

The second hand now directly updates its cumulative rotation state within `updateanalogclock()` rather than relying on the reset-condition logic used for minute/hour hands. The formula `currentSecondTurn + newSecondRotation` with forward-continuity checks ensures the second hand rotates forward across all minute rollovers.

No changes to HTML, CSS, layout, dependencies, or API surface. The fix is confined to animation logic within a single file.

Lines changed: +15/-6

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/prem-k-r/MaterialYouNewTab/pull/219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->