### PR TITLE
Fix shortcut dock layout in narrow windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project partially follows [Semantic Versioning](https://semver.org/spec
 
 ### Fixed
 
+- Fixed shortcut dock layout in narrow windows by keeping shortcut tiles at icon size and switching to a horizontal scroller when the dock container gets cramped ([@Procoder1234556](https://github.com/Procoder1234556)) ([#225](https://github.com/prem-k-r/MaterialYouNewTab/pull/225))
 - Fixed an issue where rapid clicks on the AI Tools icon caused race conditions, leading to inconsistent shortcuts panel visibility. ([@prem-k-r](https://github.com/prem-k-r)) ([#118](https://github.com/prem-k-r/MaterialYouNewTab/pull/118))
 - Fixed shortcut name and URLs hover behavior by replacing ellipsis with clipped text for improved readability ([@prem-k-r](https://github.com/prem-k-r)) ([283f78d](https://github.com/prem-k-r/MaterialYouNewTab/pull/199/changes/283f78d6e4b202a075ca3d670c1b30cbc701c3a4))
 - Fixed wallpaper disappearing on load due to blob URL being revoked too early ([@prem-k-r](https://github.com/prem-k-r)) ([#209](https://github.com/prem-k-r/MaterialYouNewTab/pull/209))

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ MYNT: Material You New Tab is a versatile browser extension that personalizes yo
 - **Google Apps**: Quickly launch Gmail, Drive, Docs, and other Google services.
 - **Backup & Reset**: Save or restore your setup anytime, or reset everything to default with one click.
 - **Language Support**: Use the extension in your preferred language for better accessibility.
-- **Browser Compatibility**: Supports all Chromium-based browsers, including **Chrome**, **Edge**, **Brave**, and **Opera**, as well as Firefox-based browsers like **Firefox** and **Zen**.
+- **Browser Compatibility**: Supports all Chromium-based browsers, including **Chrome**, **Edge**, **Brave**, and **Opera**, as well as Firefox-based browsers like **Firefox** and **Zen**. The responsive shortcut dock improvements rely on CSS container queries, which are available in **Chrome/Chromium 105+**, **Firefox 110+**, and **Safari 16+**.
 
 ## 📥 Installation Guide
 

--- a/style.css
+++ b/style.css
@@ -2407,6 +2407,7 @@ html[lang="ur"] .qtRounder2 {
 	overflow: scroll;
 	scrollbar-width: none;
 	margin: auto;
+	container-type: inline-size;
 }
 
 #shortcuts-section::-webkit-scrollbar {
@@ -2482,6 +2483,7 @@ html[lang="ur"] .qtRounder2 {
 
 .shortcutsContainer .shortcuts {
 	position: relative;
+	flex: 0 0 var(--shortcut-size);
 	transition: all 0.3s;
 	isolation: isolate;
 }
@@ -2654,6 +2656,24 @@ body[data-bg="wallpaper"][sysTheme="systemDark"]:has(
 	width: 100% !important;
 	filter: none !important;
 	mix-blend-mode: normal !important;
+}
+
+@container (max-width: 48rem) {
+	#shortcuts-section {
+		overflow-x: auto;
+		overflow-y: hidden;
+	}
+
+	#shortcuts-section .wrapper {
+		width: 100%;
+	}
+
+	.shortcutsContainer {
+		flex-wrap: nowrap;
+		width: max-content;
+		max-width: none;
+		gap: 1.4rem;
+	}
 }
 
 /* ----------end of Shortcuts----------------- */

--- a/style.css
+++ b/style.css
@@ -2658,6 +2658,8 @@ body[data-bg="wallpaper"][sysTheme="systemDark"]:has(
 	mix-blend-mode: normal !important;
 }
 
+/* Browsers without container queries keep the default wrapping layout and the
+   viewport-based media query fallback below. */
 @container (max-width: 48rem) {
 	#shortcuts-section {
 		overflow-x: auto;


### PR DESCRIPTION
## ?? Description

This PR fixes the shortcuts dock layout in narrow windows by keeping shortcut items at their icon size and switching the dock to a horizontal scroller when the available container width becomes tight.

## ?? Visual Changes (Screenshots / Videos)

Not attached from this Codex session.

## ?? Related Issues

- Closes #139

## ? Checklist

- [x] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] My code follows the project's coding style and conventions.
- [ ] I have tested my changes thoroughly to ensure expected behavior.
- [ ] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [ ] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [x] I have updated the [CHANGELOG.md](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.

## ?? AI Assistance (Coding)

- [ ] None  
- [ ] Ideas / planning  
- [ ] Debugging / review help  
- [ ] Small code snippets  
- [ ] Partial implementation  
- [ ] Major implementation help  
- [x] Mostly AI-generated  
- [ ] Full vibe coded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes the shortcuts dock layout in narrow windows by preventing shortcut items from shrinking below icon size and switching the dock to a horizontal scroller when the container becomes constrained. It also slightly reduces dock spacing in the narrow layout to give side-tab and windowed Chrome more room.

## Changes

### README.md
- Expanded the "Browser Compatibility" / "Browser Compatibility" feature to document the responsive shortcut dock baseline and container-query support: Chrome/Chromium 105+, Firefox 110+, Safari 16+.
- Noted that browsers without container-query support fall back to the existing wrapping layout via a viewport-based media-query fallback.

### style.css
- Added `container-type: inline-size` to `#shortcuts-section` to enable container-query-driven responsiveness.
- Prevented icons from shrinking by setting `.shortcuts { flex: 0 0 var(--shortcut-size); }`.
- Added a narrow-container rule (`@container (max-width: 48rem)`) to:
  - Enable horizontal scrolling (`overflow-x: auto; overflow-y: hidden`) for the shortcuts dock.
  - Stretch the `.wrapper` to full width and switch `.shortcutsContainer` to a single-row, no-wrap layout with `width: max-content`.
  - Reduce the gap spacing to `1.4rem` in narrow layouts.
- Included a fallback note: browsers lacking container queries will retain the wrapping layout and use a viewport-based media-query fallback.

### CHANGELOG.md
- Added an Unreleased → Fixed entry describing the shortcut dock layout fix and the switch to a horizontal scroller in cramped containers.

## Testing & Notes
- Style and overflow rules in style.css were reviewed; browser automation/screenshots unavailable in this session.
- Author addressed container-query feedback in the latest push and documented support baseline.
- Latest referenced commit: 608c4eb.

## Impact
- CSS-only changes; no public API or exported symbol changes.
- Estimated review effort: Low–Medium (styles and responsive behavior).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->