### PR TITLE
Add Google AI Studio shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project partially follows [Semantic Versioning](https://semver.org/spec
 ### Added
 
 - Added support for touch-swipe and mouse-wheel gestures on the search engine icon to switch search engines when they are hidden ([@prem-k-r](https://github.com/prem-k-r)) ([#145](https://github.com/prem-k-r/MaterialYouNewTab/pull/145))
+- Added Google AI Studio to the AI Tools shortcuts ([#177](https://github.com/prem-k-r/MaterialYouNewTab/issues/177))
 - Added support for custom shortcut icons via upload, URL, or pasted SVG ([@smurf11k](https://github.com/smurf11k)), ([@prem-k-r](https://github.com/prem-k-r)) ([#187](https://github.com/prem-k-r/MaterialYouNewTab/pull/187/)), ([#199](https://github.com/prem-k-r/MaterialYouNewTab/pull/199/))
 - Added Daily Quote option to show one quote per day instead of refreshing on every new tab ([@KomeshBathula](https://github.com/KomeshBathula)) ([#141](https://github.com/prem-k-r/MaterialYouNewTab/pull/141))
 

--- a/index.html
+++ b/index.html
@@ -1026,6 +1026,17 @@
                 <div class="tLabel" id="gemini">Gemini</div>
             </a>
             <!-- ---------------- -->
+            <a href="https://aistudio.google.com/prompts/new_chat">
+                <div class="tIcon">
+                    <svg height="100%" viewBox="0 0 24 24" width="100%" xmlns="http://www.w3.org/2000/svg">
+                        <rect class="accentColor aiDarkIcons" height="100%" rx="50%" width="100%" />
+                        <path class="bgLightTint notTargeted" style="transform: scale(0.78); transform-origin: center;"
+                            d="M12 2.5a.85.85 0 0 1 .816.61l1.536 5.202 4.99 2.01a.85.85 0 0 1 0 1.576l-4.99 2.01-1.536 5.202a.85.85 0 0 1-1.632 0l-1.536-5.202-4.99-2.01a.85.85 0 0 1 0-1.576l4.99-2.01 1.536-5.202A.85.85 0 0 1 12 2.5Zm0 3.955-.955 3.235a.85.85 0 0 1-.498.546l-3.09 1.245 3.09 1.245a.85.85 0 0 1 .498.546L12 16.503l.955-3.235a.85.85 0 0 1 .498-.546l3.09-1.245-3.09-1.245a.85.85 0 0 1-.498-.546L12 6.455ZM5.5 15.5a.75.75 0 0 1 .72.538l.384 1.303 1.24.5a.75.75 0 0 1 0 1.391l-1.24.5-.384 1.303a.75.75 0 0 1-1.44 0l-.384-1.303-1.24-.5a.75.75 0 0 1 0-1.391l1.24-.5.384-1.303a.75.75 0 0 1 .72-.538Zm13-13a.75.75 0 0 1 .72.538l.272.921.877.354a.75.75 0 0 1 0 1.391l-.877.354-.272.921a.75.75 0 0 1-1.44 0l-.272-.921-.877-.354a.75.75 0 0 1 0-1.391l.877-.354.272-.921a.75.75 0 0 1 .72-.538Z" />
+                    </svg>
+                </div>
+                <div class="tLabel" id="googleAIStudio">Google AI Studio</div>
+            </a>
+            <!-- ---------------- -->
             <a href="https://copilot.microsoft.com/">
                 <div class="tIcon">
                     <svg height="100%" width="100%" viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">

--- a/locales/en.js
+++ b/locales/en.js
@@ -154,6 +154,7 @@ const en = {
     "ai_tools": "AI Tools",
     "chatGPT": "ChatGPT",
     "gemini": "Gemini",
+    "googleAIStudio": "Google AI Studio",
     "copilot": "Copilot",
     "claude": "Claude",
     "grok": "Grok",

--- a/scripts/ai-tools.js
+++ b/scripts/ai-tools.js
@@ -10,14 +10,15 @@
 const aiToolsRaw = [
     { id: "chatGPT", visible: true, order: 0 },
     { id: "gemini", visible: true, order: 1 },
-    { id: "copilot", visible: true, order: 2 },
-    { id: "claude", visible: true, order: 3 },
-    { id: "deepseek", visible: true, order: 4 },
-    { id: "perplexity", visible: false, order: 5 },
-    { id: "grok", visible: false, order: 6 },
-    { id: "metaAI", visible: false, order: 7 },
-    { id: "qwen", visible: false, order: 8 },
-    { id: "firefly", visible: false, order: 9 }
+    { id: "googleAIStudio", visible: false, order: 2 },
+    { id: "copilot", visible: true, order: 3 },
+    { id: "claude", visible: true, order: 4 },
+    { id: "deepseek", visible: true, order: 5 },
+    { id: "perplexity", visible: false, order: 6 },
+    { id: "grok", visible: false, order: 7 },
+    { id: "metaAI", visible: false, order: 8 },
+    { id: "qwen", visible: false, order: 9 },
+    { id: "firefly", visible: false, order: 10 }
 ];
 // Translations for AI tools
 const aiTools = aiToolsRaw.map(tool => ({
@@ -38,6 +39,29 @@ const saveAISettingsBtn = document.getElementById("saveAISettingsBtn");
 const aiToolsEditButton = document.getElementById("aiToolsEditButton");
 const aiToolsCont = document.getElementById("aiToolsCont");
 const aiToolsEditField = document.getElementById("aiToolsEditField");
+
+function createDefaultAIToolsSettings() {
+    return aiTools.map(tool => tool.visible ? tool.id : { [tool.id]: false });
+}
+
+function getAIToolId(settingItem) {
+    if (typeof settingItem === "string") return settingItem;
+    if (settingItem && typeof settingItem === "object") return Object.keys(settingItem)[0];
+    return null;
+}
+
+function mergeAIToolsSettings(savedSettings) {
+    const defaultSettings = createDefaultAIToolsSettings();
+    if (!Array.isArray(savedSettings)) return defaultSettings;
+
+    const savedToolIds = new Set(savedSettings.map(getAIToolId).filter(Boolean));
+    const missingSettings = defaultSettings.filter(settingItem => {
+        const toolId = getAIToolId(settingItem);
+        return toolId && !savedToolIds.has(toolId);
+    });
+
+    return [...savedSettings, ...missingSettings];
+}
 
 // Animation helper function
 function animateReorder(element1, element2, direction) {
@@ -129,14 +153,10 @@ function saveAIToolsSettings() {
 // Function to apply saved settings (visibility and order)
 function applyAIToolsSettings() {
     const savedSettings = JSON.parse(localStorage.getItem("aiToolsSettings") || "null");
-    let settingsToApply;
+    const settingsToApply = mergeAIToolsSettings(savedSettings);
 
-    if (!savedSettings || !Array.isArray(savedSettings)) {
-        // Initialize with default values if no settings exist
-        settingsToApply = aiTools.map(tool => tool.visible ? tool.id : { [tool.id]: false });
+    if (JSON.stringify(savedSettings) !== JSON.stringify(settingsToApply)) {
         localStorage.setItem("aiToolsSettings", JSON.stringify(settingsToApply));
-    } else {
-        settingsToApply = savedSettings;
     }
 
     // Create a map of current tool elements for quick lookup
@@ -152,15 +172,9 @@ function applyAIToolsSettings() {
 
     // Append tools in order based on settings
     settingsToApply.forEach(item => {
-        let toolId, isVisible;
-
-        if (typeof item === "string") {
-            toolId = item;
-            isVisible = true;
-        } else {
-            toolId = Object.keys(item)[0];
-            isVisible = false;
-        }
+        const toolId = getAIToolId(item);
+        const isVisible = typeof item === "string";
+        if (!toolId) return;
 
         const toolElement = toolElements.get(toolId);
         if (toolElement) {
@@ -176,15 +190,9 @@ function generateAIToolsForm(settings) {
 
     // Create form elements
     settings.forEach((settingItem, index) => {
-        let toolId, isVisible;
-
-        if (typeof settingItem === "string") {
-            toolId = settingItem;
-            isVisible = true;
-        } else {
-            toolId = Object.keys(settingItem)[0];
-            isVisible = false;
-        }
+        const toolId = getAIToolId(settingItem);
+        const isVisible = typeof settingItem === "string";
+        if (!toolId) return;
 
         const originalTool = aiTools.find(t => t.id === toolId);
         const toolLabel = originalTool?.label || toolId;
@@ -244,19 +252,7 @@ function showAIToolsSettings() {
 
     // Load saved tool order and visibility or initialize from defaults
     let savedSettings = JSON.parse(localStorage.getItem("aiToolsSettings") || "null");
-
-    // If no settings exist, create from aiTools
-    if (!savedSettings || !Array.isArray(savedSettings)) {
-        savedSettings = aiTools.map(tool => {
-            if (tool.visible) {
-                return tool.id;
-            } else {
-                const hiddenTool = {};
-                hiddenTool[tool.id] = false;
-                return hiddenTool;
-            }
-        });
-    }
+    savedSettings = mergeAIToolsSettings(savedSettings);
 
     // Generate the form with the saved settings
     generateAIToolsForm(savedSettings);
@@ -382,15 +378,7 @@ document.addEventListener("DOMContentLoaded", function () {
     // Reset button in settings modal
     resetAISettingsBtn.addEventListener("click", function () {
         // Create default settings
-        const defaultSettings = aiTools.map(tool => {
-            if (tool.visible) {
-                return tool.id;
-            } else {
-                const hiddenTool = {};
-                hiddenTool[tool.id] = false;
-                return hiddenTool;
-            }
-        });
+        const defaultSettings = createDefaultAIToolsSettings();
 
         // Generate the form with default settings
         generateAIToolsForm(defaultSettings);

--- a/scripts/ai-tools.js
+++ b/scripts/ai-tools.js
@@ -54,13 +54,19 @@ function mergeAIToolsSettings(savedSettings) {
     const defaultSettings = createDefaultAIToolsSettings();
     if (!Array.isArray(savedSettings)) return defaultSettings;
 
-    const savedToolIds = new Set(savedSettings.map(getAIToolId).filter(Boolean));
+    const validToolIds = new Set(aiToolsRaw.map(tool => tool.id));
+    const normalizedSavedSettings = savedSettings.filter(settingItem => {
+        const toolId = getAIToolId(settingItem);
+        return toolId && validToolIds.has(toolId);
+    });
+
+    const savedToolIds = new Set(normalizedSavedSettings.map(getAIToolId));
     const missingSettings = defaultSettings.filter(settingItem => {
         const toolId = getAIToolId(settingItem);
         return toolId && !savedToolIds.has(toolId);
     });
 
-    return [...savedSettings, ...missingSettings];
+    return [...normalizedSavedSettings, ...missingSettings];
 }
 
 // Animation helper function

--- a/scripts/languages.js
+++ b/scripts/languages.js
@@ -194,6 +194,7 @@ function applyLanguage(lang) {
         "quoraEngine",
         "chatGPT",
         "gemini",
+        "googleAIStudio",
         "copilot",
         "claude",
         "grok",


### PR DESCRIPTION
## 📌 Description

Adds Google AI Studio as an AI Tools shortcut linking to `https://aistudio.google.com/prompts/new_chat`.

The shortcut is hidden by default, matching the existing optional AI tools pattern, and existing saved AI Tools settings now append newly-added default tools so current users can opt into Google AI Studio without resetting their existing order.

## 🎨 Visual Changes (Screenshots / Videos)

No screenshot attached from this environment. The visible change is one additional hidden-by-default AI Tools option that appears in the AI Tools settings list and can be enabled by the user.

## 🔗 Related Issues

- Closes #177

## ✅ Checklist

- [x] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] My code follows the project's coding style and conventions.
- [ ] I have tested my changes thoroughly to ensure expected behavior.
  - Static checks run: `git diff --check`, `node --check scripts/ai-tools.js`, `node --check scripts/languages.js`, and a repository consistency check for the new tool id/link.
- [ ] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [ ] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [x] I have updated the [CHANGELOG.md](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.

## 🤖 AI Assistance (Coding)

- [ ] None  
- [ ] Ideas / planning  
- [ ] Debugging / review help  
- [ ] Small code snippets  
- [x] Partial implementation  
- [ ] Major implementation help  
- [ ] Mostly AI-generated  
- [ ] Full vibe coded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds **Google AI Studio** as a new **AI Tools** shortcut linking to `https://aistudio.google.com/prompts/new_chat`. It integrates with the existing optional AI tools system so the shortcut is **hidden by default** and can be enabled via AI Tools settings, while ensuring current users’ saved tool preferences are preserved.

## Changes

**CHANGELOG.md**
- Added an Unreleased entry documenting Google AI Studio in the AI Tools shortcuts list.

**index.html**
- Added a new **“Google AI Studio”** tile/link (inline SVG icon and destination URL) in the AI tools section.
- Adjusted closing HTML tag whitespace/position.

**locales/en.js**
- Added the `googleAIStudio` localization string with value **“Google AI Studio”**.

**scripts/ai-tools.js**
- Extended the AI tools catalog (`aiToolsRaw`) to include Google AI Studio, including default visibility/order changes.
- Added helpers to:
  - compute default per-tool visibility
  - extract a tool id from either string or object entries
  - merge saved settings with defaults so newly introduced tools are appended without disrupting existing user order/preferences
- Updated `applyAIToolsSettings()` and `showAIToolsSettings()` to always merge saved settings with defaults, and to avoid rewriting `localStorage` unless merged settings differ from the previously loaded ones.
- Refactored tool rendering and settings form generation to use the shared id/visibility helpers.
- Updated the reset handler to use the shared default-settings helper.

**scripts/languages.js**
- Added `googleAIStudio` to the `translationMap` so language switching populates the new AI tools UI text.

## Implementation Notes
- Follows the existing AI tools pattern: **Google AI Studio is opt-in** via the AI Tools settings UI.
- Preserves existing saved AI Tools settings by **merging defaults with saved tool entries** rather than overwriting user configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->