### PR TITLE
Add toggle to disable open animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project partially follows [Semantic Versioning](https://semver.org/spec
 - Added support for touch-swipe and mouse-wheel gestures on the search engine icon to switch search engines when they are hidden ([@prem-k-r](https://github.com/prem-k-r)) ([#145](https://github.com/prem-k-r/MaterialYouNewTab/pull/145))
 - Added support for custom shortcut icons via upload, URL, or pasted SVG ([@smurf11k](https://github.com/smurf11k)), ([@prem-k-r](https://github.com/prem-k-r)) ([#187](https://github.com/prem-k-r/MaterialYouNewTab/pull/187/)), ([#199](https://github.com/prem-k-r/MaterialYouNewTab/pull/199/))
 - Added Daily Quote option to show one quote per day instead of refreshing on every new tab ([@KomeshBathula](https://github.com/KomeshBathula)) ([#141](https://github.com/prem-k-r/MaterialYouNewTab/pull/141))
+- Added a toggle to disable the entrance animations that play when a new tab opens ([@MarkQuach12](https://github.com/MarkQuach12)) ([#52](https://github.com/prem-k-r/MaterialYouNewTab/issues/52))
 
 ### Improved
 

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     <script defer src="scripts/alert-modal.js"></script>
     <script defer src="scripts/wallpaper.js"></script>
     <script defer src="scripts/widgets-transparency.js"></script>
+    <script defer src="scripts/animations-toggle.js"></script>
     <script defer src="scripts/clock.js"></script>
     <script defer src="scripts/weather.js"></script>
     <script defer src="scripts/custom-text.js"></script>
@@ -1362,6 +1363,17 @@
                                         </div>
                                         <label class="switch">
                                             <input id="todoListCheckbox" type="checkbox">
+                                            <span class="toggle"></span>
+                                        </label>
+                                    </div>
+
+                                    <div class="ttcont" id="disableAnimationsContainer">
+                                        <div class="texts">
+                                            <div class="bigText" id="disableAnimationsText">Disable Open Animations</div>
+                                            <div class="infoText" id="disableAnimationsInfo">Turn off the entrance animations when a new tab opens</div>
+                                        </div>
+                                        <label class="switch">
+                                            <input id="disableAnimations" type="checkbox">
                                             <span class="toggle"></span>
                                         </label>
                                     </div>

--- a/locales/en.js
+++ b/locales/en.js
@@ -43,6 +43,8 @@ const en = {
     "todoListInfo": "Show a daily To Do list",
     "todoListHover": "ToDo List",    // Keep this short
     "todoPlaceholder": "Add task...",
+    "disableAnimationsText": "Disable Open Animations",
+    "disableAnimationsInfo": "Turn off the entrance animations when a new tab opens",
 
     // Clock
     "hideClockBox": "Hide Clock",

--- a/scripts/animations-toggle.js
+++ b/scripts/animations-toggle.js
@@ -1,0 +1,27 @@
+/*
+ * Material You New Tab
+ * Copyright (c) 2024-2026 Prem, 2023-2025 XengShi
+ * Licensed under the GNU General Public License v3.0 (GPL-3.0)
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+// Disable Open Animations toggle: toggle the "no-open-animations"
+// class on <html>. preload.js applies it pre-paint to avoid a flash.
+const disableAnimationsKey = "disableOpenAnimations";
+const disableAnimationsCheckbox = document.getElementById("disableAnimations");
+
+function applyDisableAnimations(isDisabled) {
+    document.documentElement.classList.toggle("no-open-animations", isDisabled);
+}
+
+const animationsDisabled = localStorage.getItem(disableAnimationsKey) === "true";
+disableAnimationsCheckbox.checked = animationsDisabled;
+applyDisableAnimations(animationsDisabled);
+
+disableAnimationsCheckbox.addEventListener("change", function () {
+    const isDisabled = disableAnimationsCheckbox.checked;
+    localStorage.setItem(disableAnimationsKey, isDisabled);
+    applyDisableAnimations(isDisabled);
+});

--- a/scripts/clock.js
+++ b/scripts/clock.js
@@ -107,10 +107,20 @@ async function initializeClock() {
     cumulativeMinuteRotation = initialMinutes * 6 + (initialSeconds / 10);
     cumulativeHourRotation = (30 * initialHours + initialMinutes / 2);
 
-    // Apply initial rotations (no need to wait 1s now)
+    // Apply initial rotations (no need to wait 1s now).
+    // When open animations are off, snap the hands into place with no entrance sweep.
+    const snapClockHands = document.documentElement.classList.contains("no-open-animations");
+    if (snapClockHands) {
+        document.getElementById("second").style.transition = "none";
+        document.getElementById("minute").style.transition = "none";
+        document.getElementById("hour").style.transition = "none";
+    }
     document.getElementById("second").style.transform = `rotate(${cumulativeSecondRotation}deg)`;
     document.getElementById("minute").style.transform = `rotate(${cumulativeMinuteRotation}deg)`;
     document.getElementById("hour").style.transform = `rotate(${cumulativeHourRotation}deg)`;
+    if (snapClockHands) {
+        void document.getElementById("second").offsetHeight; // commit the snap before transitions resume
+    }
 
     function initializeClockType() {
         const savedClockType = localStorage.getItem("clocktype");

--- a/scripts/languages.js
+++ b/scripts/languages.js
@@ -138,6 +138,8 @@ function applyLanguage(lang) {
         "googleAppsMenuInfo",
         "todoListText",
         "todoListInfo",
+        "disableAnimationsText",
+        "disableAnimationsInfo",
         "fahrenheitCelsiusCheckbox",
         "fahrenheitCelsiusText",
         "minMaxTempText",

--- a/scripts/preload.js
+++ b/scripts/preload.js
@@ -8,3 +8,8 @@
 
 // Set Loading Screen Color before Everything Loads
 document.documentElement.style.setProperty('--Loading-Screen-Color', localStorage.getItem('LoadingScreenColor') || "#bbd6fd");
+
+// Apply the "disable open animations" preference before paint to avoid a flash
+if (localStorage.getItem('disableOpenAnimations') === "true") {
+    document.documentElement.classList.add("no-open-animations");
+}

--- a/style.css
+++ b/style.css
@@ -1499,6 +1499,19 @@ body #bookmarkButton.bookmark-button.rotate {
 	}
 }
 
+/* Disable on-open animations when opted out */
+html.no-open-animations #clock svg,
+html.no-open-animations .rightDiv .topDiv .rAndakar {
+	animation: none;
+}
+
+/* These only animate when their value first loads, so snap them into place.
+   The clock hands are handled in clock.js so they keep ticking smoothly. */
+html.no-open-animations .humidityBar .slider,
+html.no-open-animations .authorName {
+	transition: none;
+}
+
 .clock .centerPoint {
 	width: 20px;
 	height: 20px;


### PR DESCRIPTION
## 📌 Description

Adds a **Disable Open Animations** toggle in the settings menu, under the Personalization section, that turns off the entrance animations that play when a new tab opens. This resolves #52.

When you turn it on, these show up right away in their final state instead of animating in:
- The clock face spinning in, and the hands sweeping round to the current time
- The weather pill rotating in
- The humidity bar filling up
- The motivational quote's author pill expanding out

## 🎨 Visual Changes (Screenshots / Videos)

https://github.com/user-attachments/assets/d5ac2363-9bad-46b2-93c1-704a0ab972c4

## 🔗 Related Issues

- Closes #52 

## ✅ Checklist

<!-- Tip: To mark a checklist item as complete, replace [ ] with [x] -->

- [X] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CONTRIBUTING.md).
- [X] My code follows the project's coding style and conventions.
- [X] I have tested my changes thoroughly to ensure expected behavior.
- [X] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [X] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [X] I have updated the [CHANGELOG.md](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.

## 🤖 AI Assistance (Coding)

- [ ] None  
- [ ] Ideas / planning  
- [ ] Debugging / review help  
- [X] Small code snippets  
- [ ] Partial implementation  
- [ ] Major implementation help  
- [ ] Mostly AI-generated  
- [ ] Full vibe coded

(PS very new at making pr's so feedback appreciated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a new “Disable Open Animations” setting under Personalization that lets users turn off the new-tab entrance animations.

- Added the toggle to the settings UI and localized its text.
- Persisted the preference in localStorage and applied it early on page load to prevent animation flashes.
- Updated clock, weather, humidity, and author-pill styles/logic so they render immediately when the option is enabled.
- Updated the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->