### PR TITLE
Add missing Spanish translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project partially follows [Semantic Versioning](https://semver.org/spec
 - Translation updated for:
   - Japanese ([@kons10](https://github.com/kons10))
   - Arabic ([@heshamoomar](https://github.com/heshamoomar))
-  - Spanish ([@palacios22c](https://github.com/palacios22c))
+  - Spanish ([@palacios22c](https://github.com/palacios22c)), ([@deeferentleeg](https://github.com/deeferentleeg))
   - Russian ([@C0dwiz](https://github.com/C0dwiz), [@giwih](https://github.com/giwih)), ([@smurf11k](https://github.com/smurf11k))
   - Czech ([@ceskyDJ](https://github.com/ceskyDJ))
   - Hindi ([@prem-k-r](https://github.com/prem-k-r))

--- a/locales/es.js
+++ b/locales/es.js
@@ -1,5 +1,6 @@
 // Spanish
 const es = {
+    "newTabTitle": "Nueva Pestaña",
     // Menu Items
     "github": "GitHub",
     "feedback": "Comentarios",
@@ -30,6 +31,12 @@ const es = {
     "googleAppsMenuText": "Aplicaciones de Google",
     "googleAppsMenuInfo": "Mostrar accesos directos a las apps de Google",
     "googleAppsHover": "Aplicaciones de Google",
+
+    "shortcutDefaultName": "Nuevo Acceso Directo",
+    "shortcutInputName": "Nombre del Acceso Directo",
+    "shortcutInputUrl": "URL del Acceso Directo",
+    "shortcutInputIcon": "Icono personalizado: URL o SVG (opcional)",
+    "recentlyAddedBookmarks": "Añadidos recientemente",
 
     // To-do List
     "todoListText": "Lista de tareas",
@@ -66,6 +73,8 @@ const es = {
     "hideSearchWithInfo": "Cambiar entre motores de búsqueda haciendo click en \"Buscar con\"",
     "motivationalQuotesText": "Citas motivacionales",
     "motivationalQuotesInfo": "Mostrar citas debajo de barra de búsqueda",
+    "newQuoteOnRefreshText": "Cita del día",
+    "newQuoteOnRefreshInfo": "Mostrar una cita por día en lugar de cambiar cada vez",
     "search_suggestions_button": "Sugerencias de búsqueda",
     "search_suggestions_text": "Habilitar sugerencias de búsqueda",
 
@@ -208,4 +217,9 @@ const es = {
     "deleteBookmark": "¿Estás seguro de que deseas eliminar el marcador \"{title}\"?",
     "UnsupportedBrowser": "Los marcadores no son compatibles con tu navegador",
     "resetShortcutsPrompt": "Todos los marcadores guardados serán eliminados y restablecidos ¿Deseas continuar?",
+    "invalidFileTypeMessage": "Por favor, selecciona un archivo de imagen válido.",
+    "invalidSvgMessage": "El SVG insertado no es válido o contiene contenido no seguro y no puede usarse como icono.",
+    "invalidIconUrlMessage": "Por favor, introduce una URL de imagen válida (debe comenzar con https://, http://, o data:image/).",
+    "iconFileTooLargeMessage": "El archivo seleccionado es demasiado grande: {size} KB. Por favor, usa un archivo inferior a {max} KB.",
+    "iconStorageQuotaMessage": "No se pudo guardar el icono porque se ha alcanzado el límite de almacenamiento. Elimina algunos iconos personalizados o usa una imagen más pequeña."
 };


### PR DESCRIPTION
## Summary

This PR adds 13 missing i18n keys to `locales/es.js` to bring the Spanish locale to full parity with the English source (`locales/en.js`).

The missing keys were identified by comparing `locales/es.js` against `locales/en.js` — the same category of parity gap addressed for French in #234 (shortcut, quote, and icon validation strings), plus the `newTabTitle` key that was added in the localized New Tab title update.

## Keys added

| Key | English source | Spanish translation |
|---|---|---|
| `newTabTitle` | New Tab | Nueva Pestaña |
| `shortcutDefaultName` | New Shortcut | Nuevo Acceso Directo |
| `shortcutInputName` | Shortcut Name | Nombre del Acceso Directo |
| `shortcutInputUrl` | Shortcut URL | URL del Acceso Directo |
| `shortcutInputIcon` | Custom Icon: URL or SVG (optional) | Icono personalizado: URL o SVG (opcional) |
| `recentlyAddedBookmarks` | Recently Added | Añadidos recientemente |
| `newQuoteOnRefreshText` | Daily Quote | Cita del día |
| `newQuoteOnRefreshInfo` | Show one quote per day instead of refreshing each time | Mostrar una cita por día en lugar de cambiar cada vez |
| `invalidFileTypeMessage` | Please select a valid image file. | Por favor, selecciona un archivo de imagen válido. |
| `invalidSvgMessage` | Inserted SVG is invalid, or it contains unsafe content and cannot be used as an icon. | El SVG insertado no es válido o contiene contenido no seguro y no puede usarse como icono. |
| `invalidIconUrlMessage` | Please enter a valid image URL (must start with https://, http://, or data:image/). | Por favor, introduce una URL de imagen válida (debe comenzar con https://, http://, o data:image/). |
| `iconFileTooLargeMessage` | Selected file is too large: {size} KB. Please use a file smaller than {max} KB. | El archivo seleccionado es demasiado grande: {size} KB. Por favor, usa un archivo inferior a {max} KB. |
| `iconStorageQuotaMessage` | Icon couldn't be saved because the storage limit has been reached. Remove some custom icons or use a smaller image. | No se pudo guardar el icono porque se ha alcanzado el límite de almacenamiento. Elimina algunos iconos personalizados o usa una imagen más pequeña. |

## Changes

- **`locales/es.js`**: Added the 13 missing key-value pairs with accurate Spanish translations, matching the existing file style and key ordering. No existing keys were modified.
- **`CHANGELOG.md`**: Added contributor attribution under the `Localized` section in `[Unreleased]` (Spanish).

This follows the same approach as #234, which brought the French locale to parity with the same set of keys.

> **Note:** This PR was prepared with the assistance of AI tools. The translations were written to match the existing Spanish locale's tone and terminology, and the key ordering mirrors the English source file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added 13 missing Spanish translations for New Tab titles, shortcuts, bookmarks, daily quotes, and custom icon validation/storage messages.
- Added Spanish contributor attribution to the Unreleased changelog section.
- No existing translations were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->