### PR TITLE
Prevent theme flash with preload script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project partially follows [Semantic Versioning](https://semver.org/spec
 - Fixed an issue where rapid clicks on the AI Tools icon caused race conditions, leading to inconsistent shortcuts panel visibility. ([@prem-k-r](https://github.com/prem-k-r)) ([#118](https://github.com/prem-k-r/MaterialYouNewTab/pull/118))
 - Fixed shortcut name and URLs hover behavior by replacing ellipsis with clipped text for improved readability ([@prem-k-r](https://github.com/prem-k-r)) ([283f78d](https://github.com/prem-k-r/MaterialYouNewTab/pull/199/changes/283f78d6e4b202a075ca3d670c1b30cbc701c3a4))
 - Fixed wallpaper disappearing on load due to blob URL being revoked too early ([@prem-k-r](https://github.com/prem-k-r)) ([#209](https://github.com/prem-k-r/MaterialYouNewTab/pull/209))
+- Fixed the page briefly flashing blue (FOUC) when opening a new tab by applying saved themes before the page renders ([@itz-rj-here](https://github.com/itz-rj-here)) ([#238](https://github.com/prem-k-r/MaterialYouNewTab/pull/238))
 
 ### Localized
 

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
     <script src="locales/sv.js"></script>
 </head>
 
-<body>
+<body data-bg="color">
     <!-- --------------------- Loading Screen Starting --------------------- -->
     <img src="./images/Loading.png" id="LoadingScreen" fetchpriority="high" />
 

--- a/manifest(firefox).json
+++ b/manifest(firefox).json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "MYNT: Material You New Tab",
-	"version": "3.3.613",
+	"version": "3.3.802",
 	"description": "A Simple New Tab (browser's home page) inspired by Google's 'Material You' design.",
 	"permissions": [
 		"search",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "MYNT: Material You New Tab",
-	"version": "3.3.613",
+	"version": "3.3.802",
 	"description": "A Simple New Tab (browser's home page) inspired by Google's 'Material You' design.",
 	"permissions": ["search"],
 	"optional_permissions": ["bookmarks", "favicon"],

--- a/scripts/preload.js
+++ b/scripts/preload.js
@@ -6,5 +6,117 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-// Set Loading Screen Color before Everything Loads
-document.documentElement.style.setProperty('--Loading-Screen-Color', localStorage.getItem('LoadingScreenColor') || "#bbd6fd");
+// ============================================================
+// Preload: Apply saved theme BEFORE first paint to prevent flash
+// This script runs synchronously in <head>, before <body> exists.
+// We can only access document.documentElement (<html>).
+// ============================================================
+
+(function () {
+    const root = document.documentElement;
+
+    // --- Loading Screen Color (existing behavior) ---
+    root.style.setProperty(
+        '--Loading-Screen-Color',
+        localStorage.getItem('LoadingScreenColor') || '#bbd6fd'
+    );
+
+    // --- Widget transparency ---
+    const savedOpacity = localStorage.getItem('bgOpacity');
+    if (savedOpacity) {
+        root.style.setProperty('--transparency', `${Math.round(Number(savedOpacity))}%`);
+    }
+
+    // --- Light/Dark/System mode preference ---
+    const preferredTheme = localStorage.getItem('preferredTheme');
+    // Migrate legacy dark mode checkbox
+    const legacyDarkCheckbox = localStorage.getItem('enableDarkModeCheckboxState');
+    let resolvedPreference = preferredTheme || 'light';
+
+    if (legacyDarkCheckbox === 'checked' && !preferredTheme) {
+        resolvedPreference = 'dark';
+    }
+
+    // Set data attribute on <html> for CSS early-paint dark mode selectors
+    root.setAttribute('data-preferred-theme', resolvedPreference);
+
+    // For system theme: detect if OS is in dark mode
+    if (resolvedPreference === 'system') {
+        const systemIsDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        root.setAttribute('data-system-dark', systemIsDark ? 'true' : 'false');
+    }
+
+    // --- Color theme application ---
+    const storedTheme = localStorage.getItem('selectedTheme');
+    const storedCustomColor = localStorage.getItem('customThemeColor');
+
+    // Helper: lighten or darken a hex color (mirrors theme.js adjustHexColor)
+    function adjustHexColor(hex, factor, isLighten) {
+        if (isLighten === undefined) isLighten = true;
+        hex = hex.replace('#', '');
+        if (hex.length === 3) {
+            hex = hex.split('').map(function (c) { return c + c; }).join('');
+        }
+        var r = parseInt(hex.substring(0, 2), 16);
+        var g = parseInt(hex.substring(2, 4), 16);
+        var b = parseInt(hex.substring(4, 6), 16);
+        if (isLighten) {
+            r = Math.floor(r + (255 - r) * factor);
+            g = Math.floor(g + (255 - g) * factor);
+            b = Math.floor(b + (255 - b) * factor);
+        } else {
+            r = Math.floor(r * (1 - factor));
+            g = Math.floor(g * (1 - factor));
+            b = Math.floor(b * (1 - factor));
+        }
+        return '#' + ((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1).toUpperCase();
+    }
+
+    // Helper: check if a color is near white (mirrors theme.js isNearWhite)
+    function isNearWhite(hex, threshold) {
+        if (threshold === undefined) threshold = 240;
+        hex = hex.replace('#', '');
+        var r = parseInt(hex.substring(0, 2), 16);
+        var g = parseInt(hex.substring(2, 4), 16);
+        var b = parseInt(hex.substring(4, 6), 16);
+        return r > threshold && g > threshold && b > threshold;
+    }
+
+    if (storedCustomColor) {
+        // --- Custom color theme ---
+        var adjustedColor = isNearWhite(storedCustomColor) ? '#696969' : storedCustomColor;
+
+        var lighterColorHex = adjustHexColor(adjustedColor, 0.7);
+        var lightTin = adjustHexColor(adjustedColor, 0.9);
+        var darkerColorHex = adjustHexColor(adjustedColor, 0.3, false);
+        var darkTextColor = adjustHexColor(adjustedColor, 0.8, false);
+
+        root.style.setProperty('--bg-color-blue', lighterColorHex);
+        root.style.setProperty('--accentLightTint-blue', lightTin);
+        root.style.setProperty('--darkerColor-blue', darkerColorHex);
+        root.style.setProperty('--darkColor-blue', adjustedColor);
+        root.style.setProperty('--textColorDark-blue', darkTextColor);
+        root.style.setProperty('--whitishColor-blue', '#ffffff');
+
+    } else if (storedTheme && storedTheme !== 'blue') {
+        // --- Predefined theme (not blue, since blue is the CSS default) ---
+        var isDarkMode = storedTheme === 'dark';
+        var prefix = isDarkMode ? 'dark' : storedTheme;
+
+        root.style.setProperty('--bg-color-blue', 'var(--bg-color-' + prefix + ')');
+        root.style.setProperty('--accentLightTint-blue', 'var(--accentLightTint-' + prefix + ')');
+        root.style.setProperty('--darkerColor-blue', 'var(--darkerColor-' + prefix + ')');
+        root.style.setProperty('--darkColor-blue', 'var(--darkColor-' + prefix + ')');
+        root.style.setProperty('--textColorDark-blue', 'var(--textColorDark-' + prefix + ')');
+
+        if (!isDarkMode) {
+            root.style.setProperty('--whitishColor-blue', 'var(--whitishColor-' + storedTheme + ')');
+        }
+
+        // Add black-theme class for the "dark" color preset
+        if (isDarkMode) {
+            root.classList.add('black-theme');
+        }
+    }
+    // If storedTheme is "blue" or absent (and no custom color), CSS defaults are correct — do nothing.
+})();

--- a/scripts/preload.js
+++ b/scripts/preload.js
@@ -78,12 +78,12 @@
 
     if (storedCustomColor) {
         // --- Custom color theme ---
-        var adjustedColor = isNearWhite(storedCustomColor) ? '#696969' : storedCustomColor;
+        var adjustedColor = window.ThemeHelpers.isNearWhite(storedCustomColor) ? '#696969' : storedCustomColor;
 
-        var lighterColorHex = adjustHexColor(adjustedColor, 0.7);
-        var lightTin = adjustHexColor(adjustedColor, 0.9);
-        var darkerColorHex = adjustHexColor(adjustedColor, 0.3, false);
-        var darkTextColor = adjustHexColor(adjustedColor, 0.8, false);
+        var lighterColorHex = window.ThemeHelpers.adjustHexColor(adjustedColor, 0.7);
+        var lightTin = window.ThemeHelpers.adjustHexColor(adjustedColor, 0.9);
+        var darkerColorHex = window.ThemeHelpers.adjustHexColor(adjustedColor, 0.3, false);
+        var darkTextColor = window.ThemeHelpers.adjustHexColor(adjustedColor, 0.8, false);
 
         root.style.setProperty('--bg-color-blue', lighterColorHex);
         root.style.setProperty('--accentLightTint-blue', lightTin);
@@ -112,5 +112,4 @@
             root.classList.add('black-theme');
         }
     }
-    // If storedTheme is "blue" or absent (and no custom color), CSS defaults are correct — do nothing.
 })();

--- a/scripts/preload.js
+++ b/scripts/preload.js
@@ -1,21 +1,20 @@
 /*
- * Material You NewTab
- * Copyright (c) 2023-2025 XengShi
+ * Material You New Tab
+ * Copyright (c) 2024-2026 Prem, 2023-2025 XengShi
  * Licensed under the GNU General Public License v3.0 (GPL-3.0)
  * You should have received a copy of the GNU General Public License along with this program.
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-// ============================================================
+// ===============================================================
 // Preload: Apply saved theme BEFORE first paint to prevent flash
 // This script runs synchronously in <head>, before <body> exists.
-// We can only access document.documentElement (<html>).
-// ============================================================
+// ===============================================================
 
 (function () {
     const root = document.documentElement;
 
-    // --- Loading Screen Color (existing behavior) ---
+    // --- Loading Screen Color ---
     root.style.setProperty(
         '--Loading-Screen-Color',
         localStorage.getItem('LoadingScreenColor') || '#bbd6fd'
@@ -50,37 +49,32 @@
     const storedTheme = localStorage.getItem('selectedTheme');
     const storedCustomColor = localStorage.getItem('customThemeColor');
 
-    // Helper: lighten or darken a hex color (mirrors theme.js adjustHexColor)
-    function adjustHexColor(hex, factor, isLighten) {
-        if (isLighten === undefined) isLighten = true;
-        hex = hex.replace('#', '');
-        if (hex.length === 3) {
-            hex = hex.split('').map(function (c) { return c + c; }).join('');
+    window.ThemeHelpers = {
+        adjustHexColor: function (hex, factor, isLighten = true) {
+            hex = hex.replace('#', '');
+            if (hex.length === 3) hex = hex.split('').map(c => c + c).join('');
+            let r = parseInt(hex.substring(0, 2), 16);
+            let g = parseInt(hex.substring(2, 4), 16);
+            let b = parseInt(hex.substring(4, 6), 16);
+            if (isLighten) {
+                r = Math.floor(r + (255 - r) * factor);
+                g = Math.floor(g + (255 - g) * factor);
+                b = Math.floor(b + (255 - b) * factor);
+            } else {
+                r = Math.floor(r * (1 - factor));
+                g = Math.floor(g * (1 - factor));
+                b = Math.floor(b * (1 - factor));
+            }
+            return '#' + ((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1).toUpperCase();
+        },
+        isNearWhite: function (hex, threshold = 240) {
+            hex = hex.replace('#', '');
+            let r = parseInt(hex.substring(0, 2), 16);
+            let g = parseInt(hex.substring(2, 4), 16);
+            let b = parseInt(hex.substring(4, 6), 16);
+            return r > threshold && g > threshold && b > threshold;
         }
-        var r = parseInt(hex.substring(0, 2), 16);
-        var g = parseInt(hex.substring(2, 4), 16);
-        var b = parseInt(hex.substring(4, 6), 16);
-        if (isLighten) {
-            r = Math.floor(r + (255 - r) * factor);
-            g = Math.floor(g + (255 - g) * factor);
-            b = Math.floor(b + (255 - b) * factor);
-        } else {
-            r = Math.floor(r * (1 - factor));
-            g = Math.floor(g * (1 - factor));
-            b = Math.floor(b * (1 - factor));
-        }
-        return '#' + ((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1).toUpperCase();
-    }
-
-    // Helper: check if a color is near white (mirrors theme.js isNearWhite)
-    function isNearWhite(hex, threshold) {
-        if (threshold === undefined) threshold = 240;
-        hex = hex.replace('#', '');
-        var r = parseInt(hex.substring(0, 2), 16);
-        var g = parseInt(hex.substring(2, 4), 16);
-        var b = parseInt(hex.substring(4, 6), 16);
-        return r > threshold && g > threshold && b > threshold;
-    }
+    };
 
     if (storedCustomColor) {
         // --- Custom color theme ---

--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -109,7 +109,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // Remove Loading Screen when the DOM and the theme has loaded
     document.getElementById("LoadingScreen").style.display = "none";
 
-    // Clean up preload data attributes — DOM-based selectors are now in control
+    // Clean up preload data attributes
     document.documentElement.removeAttribute("data-preferred-theme");
     document.documentElement.removeAttribute("data-system-dark");
 

--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -109,6 +109,10 @@ document.addEventListener("DOMContentLoaded", () => {
     // Remove Loading Screen when the DOM and the theme has loaded
     document.getElementById("LoadingScreen").style.display = "none";
 
+    // Clean up preload data attributes — DOM-based selectors are now in control
+    document.documentElement.removeAttribute("data-preferred-theme");
+    document.documentElement.removeAttribute("data-system-dark");
+
     // Stop blinking of some elements when the page is reloaded
     setTimeout(() => {
         document.documentElement.classList.add("theme-transition");

--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -1,6 +1,6 @@
 /*
- * Material You NewTab
- * Copyright (c) 2023-2025 XengShi
+ * Material You New Tab
+ * Copyright (c) 2024-2026 Prem, 2023-2025 XengShi
  * Licensed under the GNU General Public License v3.0 (GPL-3.0)
  */
 
@@ -192,41 +192,13 @@ function changeFaviconColor() {
 changeFaviconColor();
 
 // --------------------- Color Picker ---------------------
-function adjustHexColor(hex, factor, isLighten = true) {
-    hex = hex.replace("#", "");
-    if (hex.length === 3) {
-        hex = hex.split("").map(c => c + c).join("");
-    }
-    let r = parseInt(hex.substring(0, 2), 16);
-    let g = parseInt(hex.substring(2, 4), 16);
-    let b = parseInt(hex.substring(4, 6), 16);
-    if (isLighten) {
-        r = Math.floor(r + (255 - r) * factor);
-        g = Math.floor(g + (255 - g) * factor);
-        b = Math.floor(b + (255 - b) * factor);
-    } else {
-        r = Math.floor(r * (1 - factor));
-        g = Math.floor(g * (1 - factor));
-        b = Math.floor(b * (1 - factor));
-    }
-    return `#${((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1).toUpperCase()}`;
-}
-
-function isNearWhite(hex, threshold = 240) {
-    hex = hex.replace("#", "");
-    const r = parseInt(hex.substring(0, 2), 16);
-    const g = parseInt(hex.substring(2, 4), 16);
-    const b = parseInt(hex.substring(4, 6), 16);
-    return r > threshold && g > threshold && b > threshold;
-}
-
 const applyCustomTheme = (color) => {
-    let adjustedColor = isNearWhite(color) ? "#696969" : color;
+    let adjustedColor = window.ThemeHelpers.isNearWhite(color) ? "#696969" : color;
 
-    const lighterColorHex = adjustHexColor(adjustedColor, 0.7);
-    const lightTin = adjustHexColor(adjustedColor, 0.9);
-    const darkerColorHex = adjustHexColor(adjustedColor, 0.3, false);
-    const darkTextColor = adjustHexColor(adjustedColor, 0.8, false);
+    const lighterColorHex = window.ThemeHelpers.adjustHexColor(adjustedColor, 0.7);
+    const lightTin = window.ThemeHelpers.adjustHexColor(adjustedColor, 0.9);
+    const darkerColorHex = window.ThemeHelpers.adjustHexColor(adjustedColor, 0.3, false);
+    const darkTextColor = window.ThemeHelpers.adjustHexColor(adjustedColor, 0.8, false);
 
     document.documentElement.style.setProperty("--bg-color-blue", lighterColorHex);
     document.documentElement.style.setProperty("--accentLightTint-blue", lightTin);

--- a/scripts/widgets-transparency.js
+++ b/scripts/widgets-transparency.js
@@ -1,6 +1,6 @@
 /*
- * Material You NewTab
- * Copyright (c) 2023-2025 XengShi
+ * Material You New Tab
+ * Copyright (c) 2024-2026 Prem, 2023-2025 XengShi
  * Licensed under the GNU General Public License v3.0 (GPL-3.0)
  * You should have received a copy of the GNU General Public License along with this program.
  * If not, see <https://www.gnu.org/licenses/>.
@@ -29,7 +29,7 @@ function handleDrag(e) {
         ? rect.right - clientX  // distance from right edge
         : clientX - rect.left;  // distance from left edge
     newPos = Math.max(0, Math.min(rect.width, newPos));
-    const percentage = +((newPos / rect.width) * 100).toFixed(2);
+    const percentage = +((newPos / rect.width) * 100).toFixed(1);
     setSliderPosition(percentage);
 }
 

--- a/style.css
+++ b/style.css
@@ -221,6 +221,18 @@ body {
 	margin: 0;
 }
 
+/* Early-paint dark mode: applied by preload.js before deferred scripts run.
+   Uses data attributes on <html> set synchronously in <head>. */
+html[data-preferred-theme="dark"]:not(:has(#darkTheme:checked)),
+html[data-preferred-theme="system"][data-system-dark="true"]:not(
+		:has(#darkTheme:checked)
+	) {
+	filter: invert(1) hue-rotate(180deg);
+	-webkit-filter: invert(1) hue-rotate(180deg);
+
+	--whitishColor-blue: #f2f2f2;
+}
+
 /* Apply dark mode when: Dark Mode is selected manually, OR System Theme is selected */
 html:has(body[data-bg="color"] .menuBar .themeSegment[data-active="dark"]):not(
 		:has(#darkTheme:checked)


### PR DESCRIPTION
Add synchronous preload script that applies saved theme preferences before the first paint. This prevents the visual flash of the default theme that occurred when users had custom preferences set.

The preload script runs in the <head> before deferred scripts, applying saved settings for:
- Dark/light/system mode preference
- Color theme and custom colors
- Widget transparency
- Loading screen color

CSS dark mode rules updated to work with early-paint data attributes. Preload attributes are cleaned up after DOMContentLoaded.

## 📌 Description

<!-- Please provide a clear and concise description of the changes introduced in this PR and their purpose. -->

## 🎨 Visual Changes (Screenshots / Videos)

<!-- If applicable, attach relevant screenshots or screen recordings showcasing the modifications. -->

## 🔗 Related Issues

- Closes #<issue_number> <!-- if this PR fixes an issue -->
- Related to #<issue_number> <!-- if applicable -->

## ✅ Checklist

<!-- Tip: To mark a checklist item as complete, replace [ ] with [x] -->

- [ ] I have read and followed the [Contributing Guidelines](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CONTRIBUTING.md).
- [ ] My code follows the project's coding style and conventions.
- [ ] I have tested my changes thoroughly to ensure expected behavior.
- [ ] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [ ] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [ ] I have updated the [CHANGELOG.md](https://github.com/prem-k-r/MaterialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.

## 🤖 AI Assistance (Coding)

- [ ] None  
- [ ] Ideas / planning  
- [ ] Debugging / review help  
- [ ] Small code snippets  
- [ ] Partial implementation  
- [ ] Major implementation help  
- [ ] Mostly AI-generated  
- [ ] Full vibe coded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a synchronous head preload script to apply saved theme, custom colors, transparency, and loading-screen settings before first paint.
- Added early-paint dark-mode styling based on theme data attributes.
- Added `data-bg="color"` to the document body.
- Removed preload theme attributes after `DOMContentLoaded`.
- Centralized color helper logic in `window.ThemeHelpers`.
- Reduced widget transparency slider precision to one decimal place.
- Updated extension versions to `3.3.802`.
- Added a changelog entry for the theme flash fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->