### PR TITLE
Fix broken star history chart links

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,12 +270,12 @@ Contributions are welcome! If you’d like to contribute:
 
 Here is the star history chart for the **MYNT: Material You New Tab** repository. It shows the growth of stars over time, reflecting the increasing interest and support for the project.
 
-<a href="https://star-history.com/#prem-k-r/MaterialYouNewTab&Date">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=prem-k-r/MaterialYouNewTab&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=prem-k-r/MaterialYouNewTab&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=prem-k-r/MaterialYouNewTab&type=Date" />
- </picture>
+<a href="https://star-history.dera.page/#prem-k-r/MaterialYouNewTab&type=Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=prem-k-r/MaterialYouNewTab&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=prem-k-r/MaterialYouNewTab&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=prem-k-r/MaterialYouNewTab&type=Date" />
+  </picture>
 </a>
 
 ## ❓ Issues and Support


### PR DESCRIPTION
The star history chart in the README is broken since the old provider relies on the restricted GitHub stargazer API. Point the links to the community fork (star-history.dera.page) which needs no API token and serves both the chart and its frontend from the same origin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the README Star History links to use `star-history.dera.page`.
- Replaced `star-history.com` and `api.star-history.com` URLs.
- Restored chart rendering and same-origin frontend serving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->