### PR TITLE
feat: Add customisable keyboard shortcut for random wallpaper

### DIFF
--- a/manifest(firefox).json
+++ b/manifest(firefox).json
@@ -11,6 +11,15 @@
 		"https://search.brave.com/api/suggest?q=*",
 		"https://*.wikipedia.org/w/api.php?action=opensearch&search=*"
 	],
+	"commands": {
+		"random-wallpaper": {
+			"suggested_key": {
+				"default": "Ctrl+Shift+U",
+				"mac": "Command+Shift+U"
+			},
+			"description": "Choose a random wallpaper"
+		}
+	},
 	"background": {
 		"scripts": ["scripts/background.js"]
 	},

--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,15 @@
 		"https://search.brave.com/api/suggest?q=*",
 		"https://*.wikipedia.org/w/api.php?action=opensearch&search=*"
 	],
+	"commands": {
+		"random-wallpaper": {
+			"suggested_key": {
+				"default": "Ctrl+Shift+U",
+				"mac": "Command+Shift+U"
+			},
+			"description": "Choose a random wallpaper"
+		}
+	},
 	"icons": {
 		"16": "favicon/icon16.png",
 		"48": "favicon/icon48.png",

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -1,3 +1,10 @@
+/*
+ * Material You New Tab
+ * Copyright (c) 2024-2026 Prem, 2023-2025 XengShi
+ * Licensed under the GNU General Public License v3.0 (GPL-3.0)
+ */
+
+// Open "What's New" page on update
 chrome.runtime.onInstalled.addListener((details) => {
     if (details.reason === "update") {
         chrome.tabs.create({
@@ -6,6 +13,31 @@ chrome.runtime.onInstalled.addListener((details) => {
     }
 });
 
+// Set uninstall URL
 chrome.runtime.setUninstallURL(
     "https://forms.gle/gaR7EVS7XpzP3BsA6"
 );
+
+// Keyboard shortcuts
+chrome.commands.onCommand.addListener(async (command) => {
+    const [tab] = await chrome.tabs.query({
+        active: true,
+        lastFocusedWindow: true
+    });
+
+    if (!tab?.id) {
+        return;
+    }
+
+    try {
+        switch (command) {
+            case "random-wallpaper":
+                await chrome.tabs.sendMessage(tab.id, {
+                    action: "random-wallpaper"
+                });
+                break;
+        }
+    } catch (error) {
+        console.debug(`Could not execute command "${command}":`, error);
+    }
+});

--- a/scripts/wallpaper.js
+++ b/scripts/wallpaper.js
@@ -190,5 +190,37 @@ document.getElementById("clearImage").addEventListener("click", async function (
 
 document.getElementById("randomImageTrigger").addEventListener("click", applyRandomImage);
 
+// Keyboard shortcut for random wallpaper
+let randomWallpaperRunning = false;
+let lastRandomWallpaperTime = 0;
+
+chrome.runtime.onMessage.addListener((message) => {
+    if (message.action !== "random-wallpaper") {
+        return;
+    }
+
+    const now = Date.now();
+
+    // Ignore if previous request is still loading
+    if (randomWallpaperRunning) {
+        return;
+    }
+
+    // Ignore if less than 1 second since previous wallpaper change
+    if (now - lastRandomWallpaperTime < 1000) {
+        return;
+    }
+
+    randomWallpaperRunning = true;
+
+    applyRandomImage(false)
+        .then(() => {
+            lastRandomWallpaperTime = Date.now();
+        })
+        .finally(() => {
+            randomWallpaperRunning = false;
+        });
+});
+
 // Start image check on page load
 checkAndUpdateImage();


### PR DESCRIPTION
Add a new keyboard command (random-wallpaper) to both manifest.json and manifest(firefox).json with suggested keys (Ctrl+Shift+U / Command+Shift+U).
Update background.js: handle commands via chrome.commands.onCommand to forward a message to the active tab.
Update scripts/wallpaper.js to listen for the random-wallpaper message and call applyRandomImage with concurrency and 1s debounce guards to avoid duplicate requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add the `random-wallpaper` keyboard command to Chrome and Firefox manifests.
- Use `Ctrl+Shift+U` and `Command+Shift+U` as suggested shortcuts.
- Forward the command to the active tab from `background.js`.
- Handle the message in `wallpaper.js` and call `applyRandomImage`.
- Prevent concurrent requests and debounce successful changes for one second.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->