### PR TITLE
feat: Support direct URL navigation in search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project partially follows [Semantic Versioning](https://semver.org/spec
 - Added Daily Quote option to show one quote per day instead of refreshing on every new tab ([@KomeshBathula](https://github.com/KomeshBathula)) ([#141](https://github.com/prem-k-r/MaterialYouNewTab/pull/141))
 - Added keyboard shortcuts (`Alt + 1`–`9`) to quickly open the first nine shortcuts ([@smurf11k](https://github.com/smurf11k)) ([#237](https://github.com/prem-k-r/MaterialYouNewTab/pull/237))
 - Added Google AI Mode search button to the search bar when using Google as the search engine ([@KomeshBathula](https://github.com/KomeshBathula))
+- Updated the search bar to bypass search engines and navigate directly to webpages when the input contains no spaces and begins strictly with `http://`, `https://`, or `www.` ([@prem-k-r](https://github.com/prem-k-r)) ([#255](https://github.com/prem-k-r/MaterialYouNewTab/pull/255))
 
 ### Improved
 

--- a/docs/whats-new.html
+++ b/docs/whats-new.html
@@ -265,13 +265,16 @@
                 <section class="timeline-item">
                     <span class="timeline-dot"></span>
                     <h2 class="version">
-                        v3.3.828
+                        v3.3.902
                         <span class="current">CURRENT</span>
                     </h2>
 
                     <ul class="changes">
                         <li>
-                            Added <strong>Google AI Mode</strong> search button to the search bar when using Google as
+                            When entering a link, the search bar now opens the website directly instead of searching for it.
+                        </li>
+                        <li>
+                            Added a <strong>Google AI Mode</strong> search button to the search bar when using Google as
                             the search engine.
                         </li>
                         <li>

--- a/docs/whats-new.html
+++ b/docs/whats-new.html
@@ -168,6 +168,10 @@
             padding-left: 2px;
         }
 
+        .changes li:not(:last-child) {
+            padding-bottom: 3px;
+        }
+
         code {
             display: inline-block;
             padding: 2px 6px;

--- a/manifest(firefox).json
+++ b/manifest(firefox).json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "MYNT: Material You New Tab",
-	"version": "3.3.828",
+	"version": "3.3.902",
 	"description": "A Simple New Tab (browser's home page) inspired by Google's 'Material You' design.",
 	"permissions": [
 		"search",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "MYNT: Material You New Tab",
-	"version": "3.3.828",
+	"version": "3.3.902",
 	"description": "A Simple New Tab (browser's home page) inspired by Google's 'Material You' design.",
 	"permissions": ["search"],
 	"optional_permissions": ["bookmarks", "favicon"],

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -204,12 +204,31 @@ function swapDropdown(selectedElement) {
     });
 }
 
+// Validates strict URLs so they bypass the search engine
+function getValidUrl(text) {
+    if (text.includes(" ")) return null;
+    const lowerText = text.toLowerCase();
+    if (lowerText.startsWith("http://") || lowerText.startsWith("https://")) {
+        return text; 
+    }
+    if (lowerText.startsWith("www.")) {
+        return "https://" + text;
+    }
+    return null;
+}
+
 // Function to perform search
 function performSearch(query) {
     const selectedOption = document.querySelector('input[name="search-engine"]:checked').value;
-    const searchTerm = query || searchInput.value;
+    const searchTerm = (query || searchInput.value).trim();
 
     if (searchTerm !== "") {
+        const directUrl = getValidUrl(searchTerm);
+        if (directUrl) {
+            window.location.href = directUrl;
+            return;
+        }
+
         if (selectedOption === "engine0") {
             try {
                 if (isFirefox) {

--- a/scripts/search.js
+++ b/scripts/search.js
@@ -206,15 +206,28 @@ function swapDropdown(selectedElement) {
 
 // Validates strict URLs so they bypass the search engine
 function getValidUrl(text) {
-    if (text.includes(" ")) return null;
+    if (!text || text.includes(" ")) return null;
+
     const lowerText = text.toLowerCase();
+    let candidate = null;
+
     if (lowerText.startsWith("http://") || lowerText.startsWith("https://")) {
-        return text; 
+        candidate = text;
+    } else if (lowerText.startsWith("www.")) {
+        candidate = "https://" + text;
+    } else {
+        return null;
     }
-    if (lowerText.startsWith("www.")) {
-        return "https://" + text;
+
+    try {
+        const parsed = new URL(candidate);
+        if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+            return null;
+        }
+        return parsed.href;
+    } catch (error) {
+        return null;
     }
-    return null;
 }
 
 // Function to perform search


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added direct URL navigation in the search bar.
- Inputs that start with `http://`, `https://`, or `www.` and contain no spaces now open directly.
- Trimmed the query before empty-input and URL checks.
- Updated changelog entries and release version metadata to `3.3.902`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->