### PR TITLE
Fix quotation box artifact

### DIFF
--- a/index.html
+++ b/index.html
@@ -966,16 +966,6 @@
                 </div>
                 <div class="authorWrapper">
                     <div class="authorName"><span></span></div>
-                    <div class="qtRounder">
-                        <svg viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
-                            <path class="lessDark targeted" d="M30 0L0 0C16.5685 0 30 13.4315 30 30L30 0Z" />
-                        </svg>
-                    </div>
-                    <div class="qtRounder2">
-                        <svg viewBox="0 0 30 30" xmlns="http://www.w3.org/2000/svg">
-                            <path class="lessDark targeted" d="M30 0L0 0C16.5685 0 30 13.4315 30 30L30 0Z" />
-                        </svg>
-                    </div>
                 </div>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -2403,6 +2403,10 @@ body[data-bg="wallpaper"] .searchWithCont .hint:hover {
 	unicode-bidi: isolate;
 }
 
+.quotesCont[dir="rtl"] {
+	direction: rtl;
+}
+
 .quotesContainer {
 	position: relative;
 	background-color: var(--accentLightTint-blue);
@@ -2410,7 +2414,7 @@ body[data-bg="wallpaper"] .searchWithCont .hint:hover {
 	width: 100%;
 	border-radius: 20px;
 	padding: 20px;
-	padding-bottom: 30px;
+	padding-bottom: 40px;
 	line-height: 28px;
 }
 .authorWrapper {

--- a/style.css
+++ b/style.css
@@ -2406,26 +2406,57 @@ body[data-bg="wallpaper"] .searchWithCont .hint:hover {
 .quotesContainer {
 	position: relative;
 	background-color: var(--accentLightTint-blue);
-	height: 100px;
+	min-height: 100px;
 	width: 100%;
 	border-radius: 20px;
 	padding: 20px;
+	padding-bottom: 30px;
 	line-height: 28px;
 }
-
 .authorWrapper {
 	position: absolute;
-	bottom: 0;
-	inset-inline-end: 0;
+	bottom: -1px;
+	inset-inline-end: -1px;
 	display: flex;
 	align-items: flex-end;
 	background: var(--bg-color-blue);
-    border-start-start-radius: 20px;
-	border-end-end-radius: 20px; 
+	border-start-start-radius: 20px;
+	border-end-end-radius: 20px;
+}
+
+.authorWrapper::before {
+	content: "";
+	position: absolute;
+	inset-inline-start: -20px;
+	bottom: 0;
+	width: 21px;
+	height: 21px;
+	background: radial-gradient(circle at 0 0, transparent 19.5px, var(--bg-color-blue) 20px);
+	pointer-events: none;
+}
+
+
+.authorWrapper::after {
+	content: "";
+	position: absolute;
+	inset-inline-end: 0;
+	top: -20px;
+	width: 21px;
+	height: 21px;
+	background: radial-gradient(circle at 0 0, transparent 19.5px, var(--bg-color-blue) 20px);
+	pointer-events: none;
+}
+
+:dir(rtl) .authorWrapper::before {
+	background: radial-gradient(circle at 100% 0, transparent 19.5px, var(--bg-color-blue) 20px);
+}
+
+:dir(rtl) .authorWrapper::after {
+	background: radial-gradient(circle at 100% 0, transparent 19.5px, var(--bg-color-blue) 20px);
 }
 
 .authorName {
-	background: var(--bg-color-blue);
+	background: transparent;
 	position: relative;
 	padding: 6px 16px;
 	display: flex;
@@ -2446,23 +2477,6 @@ body[data-bg="wallpaper"] .searchWithCont .hint:hover {
 	padding: 0;
 }
 
-.qtRounder {
-	position: absolute;
-	width: 20px;
-	height: 20px;
-	inset-inline-start: -20px;
-	transform: rotate(90deg);
-}
-
-.qtRounder2 {
-	position: absolute;
-	width: 20px;
-	height: 20px;
-	inset-inline-end: 0;
-	top: -20px;
-	transform: rotate(90deg);
-}
-
 body[data-bg="wallpaper"] .quotesContainer {
 	background-color: color-mix(
 		in srgb,
@@ -2476,7 +2490,7 @@ body[data-bg="wallpaper"] .quotesContainer {
 	text-shadow: 0 0 5px rgba(0, 0, 0, 0.7);
 }
 
-body[data-bg="wallpaper"] .authorName {
+body[data-bg="wallpaper"] .authorWrapper {
 	background-color: color-mix(
 		in srgb,
 		var(--bg-color-blue) calc(var(--transparency) * 1.5),
@@ -2484,12 +2498,22 @@ body[data-bg="wallpaper"] .authorName {
 	);
 }
 
-html[lang="ur"] .qtRounder {
-	left: -18.5px;
+body[data-bg="wallpaper"] .authorWrapper::before,
+body[data-bg="wallpaper"] .authorWrapper::after {
+	background: radial-gradient(
+		circle at 0 0,
+		transparent 19.5px,
+		color-mix(in srgb, var(--bg-color-blue) calc(var(--transparency) * 1.5), transparent) 20px
+	);
 }
 
-html[lang="ur"] .qtRounder2 {
-	right: -1.5px;
+:dir(rtl) body[data-bg="wallpaper"] .authorWrapper::before,
+:dir(rtl) body[data-bg="wallpaper"] .authorWrapper::after {
+	background: radial-gradient(
+		circle at 100% 0,
+		transparent 19.5px,
+		color-mix(in srgb, var(--bg-color-blue) calc(var(--transparency) * 1.5), transparent) 20px
+	);
 }
 
 /* ----------Shortcuts----------------- */


### PR DESCRIPTION
## Description

Fixes the thin line that shows around the quotation box's author section and at some zoom levels around the box itself reported in #257.

## Root cause

The author tab was built from separate layers whose edges only touched (the pill plus two corner pieces), and its outer edge sat exactly on the box's outer edge. Edges that merely touch, or that coincide, never fully cover the same device pixel at fractional zoom, so the lighter box (or the page) shows through as a hairline. On a semi-transparent wallpaper background, overlapping layers also show as darker lines.

## Changes

- The author pill and both concave fillets are now ONE element cut with a CSS mask, so there are no internal joins.
- `.quotesCont` clips the box and the pill with a single rounded `overflow: clip`. Both the box background and the pill overhang that clip slightly, so every outer edge is drawn exactly once. `clip` rather than `hidden` so the overhang can't become scrollable.
- Restored the original fixed `height: 100px` layout  the earlier `min-height` + extra bottom padding made two-line quotes look padded. The visible box and the text position are unchanged.
- Removed the SVG corner elements from `index.html` and the related Urdu-specific tweaks.
- RTL: direction now comes from the `dir` attribute `languages.js` already sets; the mask is mirrored for `[dir="rtl"]`.
- Wallpaper mode keeps the existing `transparency × 1.5` rule for the pill, now on the single wrapper element.

## Testing

- Brave on Windows (125% display scaling), zoom 100 / 110 / 125 / 150 / 175 %: no line at the author tab or around the box.
- Wallpaper mode and plain colour mode.
- One- and two-line quotes; short and long author names.
- RTL (`dir="rtl"`): pill at bottom-left with mirrored fillets.
- Merged current `main`; no conflicts.

## Related Issue

Closes #257